### PR TITLE
[FEAT] 메인 레이아웃 구현

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,40 +1,190 @@
 import { Routes, Route } from 'react-router-dom'
-import { Box, Typography, Container, Button, Stack } from '@mui/material'
+import { Box, Typography, Container, Card, CardContent, Grid, Button } from '@mui/material'
+import {
+  RecordVoiceOver as InterviewIcon,
+  Headphones as OpicIcon,
+  Chat as FreetalkIcon,
+  Edit as WritingIcon,
+} from '@mui/icons-material'
+import MainLayout from './layouts/MainLayout'
 
-function Home() {
+// 임시 대시보드 페이지
+function Dashboard() {
+  const learningModes = [
+    {
+      id: 'interview',
+      title: '면접 시뮬레이션',
+      description: 'AI 면접관과 실전처럼 연습하세요',
+      icon: InterviewIcon,
+      color: '#0124ac',
+      path: '/interview',
+    },
+    {
+      id: 'opic',
+      title: 'OPIC 연습',
+      description: '레벨별 맞춤 문제로 실력 향상',
+      icon: OpicIcon,
+      color: '#2196f3',
+      path: '/opic',
+    },
+    {
+      id: 'freetalk',
+      title: '프리토킹',
+      description: 'AI와 자유롭게 영어로 대화',
+      icon: FreetalkIcon,
+      color: '#4caf50',
+      path: '/freetalk',
+    },
+    {
+      id: 'writing',
+      title: '작문 연습',
+      description: '문법 교정과 표현 피드백',
+      icon: WritingIcon,
+      color: '#ff9800',
+      path: '/writing',
+    },
+  ]
+
   return (
     <Container maxWidth="lg">
-      <Box sx={{ mt: 4, textAlign: 'center' }}>
-        <Typography variant="h3" component="h1" gutterBottom>
-          Welcome to FE Repository
+      <Box sx={{ mb: 4 }}>
+        <Typography variant="h4" fontWeight={700} gutterBottom>
+          안녕하세요! 👋
         </Typography>
-        <Typography variant="body1" color="text.secondary" sx={{ mb: 4 }}>
-          React + Vite + MUI 프로젝트가 준비되었습니다.
+        <Typography variant="body1" color="text.secondary">
+          오늘은 어떤 학습을 해볼까요?
         </Typography>
+      </Box>
 
-        <Stack direction="row" spacing={2} justifyContent="center" sx={{ mb: 3 }}>
-          <Button variant="contained" color="primary" size="large">
-            Primary 버튼
-          </Button>
-          <Button variant="outlined" color="primary" size="large">
-            Outlined 버튼
-          </Button>
-          <Button variant="contained" color="secondary" size="large">
-            Secondary 버튼
-          </Button>
-        </Stack>
+      <Grid container spacing={3}>
+        {learningModes.map((mode) => {
+          const Icon = mode.icon
+          return (
+            <Grid item xs={12} sm={6} md={3} key={mode.id}>
+              <Card
+                sx={{
+                  height: '100%',
+                  cursor: 'pointer',
+                  transition: 'transform 0.2s, box-shadow 0.2s',
+                  '&:hover': {
+                    transform: 'translateY(-4px)',
+                    boxShadow: 4,
+                  },
+                }}
+              >
+                <CardContent sx={{ textAlign: 'center', py: 4 }}>
+                  <Box
+                    sx={{
+                      width: 64,
+                      height: 64,
+                      borderRadius: '50%',
+                      backgroundColor: `${mode.color}15`,
+                      display: 'flex',
+                      alignItems: 'center',
+                      justifyContent: 'center',
+                      margin: '0 auto 16px',
+                    }}
+                  >
+                    <Icon sx={{ fontSize: 32, color: mode.color }} />
+                  </Box>
+                  <Typography variant="h6" fontWeight={600} gutterBottom>
+                    {mode.title}
+                  </Typography>
+                  <Typography variant="body2" color="text.secondary">
+                    {mode.description}
+                  </Typography>
+                </CardContent>
+              </Card>
+            </Grid>
+          )
+        })}
+      </Grid>
 
-        <Box sx={{
-          mt: 4,
-          p: 3,
-          bgcolor: 'primary.main',
-          color: 'white',
-          borderRadius: 2
-        }}>
-          <Typography variant="h6">
-            Primary Color: #0124ac
-          </Typography>
-        </Box>
+      {/* 최근 학습 */}
+      <Box sx={{ mt: 6 }}>
+        <Typography variant="h5" fontWeight={600} gutterBottom>
+          최근 학습
+        </Typography>
+        <Card>
+          <CardContent>
+            <Typography color="text.secondary" textAlign="center" py={4}>
+              아직 학습 기록이 없습니다. 학습을 시작해보세요!
+            </Typography>
+          </CardContent>
+        </Card>
+      </Box>
+    </Container>
+  )
+}
+
+// 임시 페이지들
+function InterviewPage() {
+  return (
+    <Container>
+      <Typography variant="h4">면접 시뮬레이션</Typography>
+      <Typography color="text.secondary">AI 면접관과 실전 연습</Typography>
+    </Container>
+  )
+}
+
+function OpicPage() {
+  return (
+    <Container>
+      <Typography variant="h4">OPIC 연습</Typography>
+      <Typography color="text.secondary">레벨별 맞춤 연습</Typography>
+    </Container>
+  )
+}
+
+function FreetalkPage() {
+  return (
+    <Container>
+      <Typography variant="h4">프리토킹</Typography>
+      <Typography color="text.secondary">AI와 자유로운 대화</Typography>
+    </Container>
+  )
+}
+
+function WritingPage() {
+  return (
+    <Container>
+      <Typography variant="h4">작문 연습</Typography>
+      <Typography color="text.secondary">문법 교정 & 피드백</Typography>
+    </Container>
+  )
+}
+
+function ReportsPage() {
+  return (
+    <Container>
+      <Typography variant="h4">내 리포트</Typography>
+      <Typography color="text.secondary">학습 결과 분석</Typography>
+    </Container>
+  )
+}
+
+function SettingsPage() {
+  return (
+    <Container>
+      <Typography variant="h4">설정</Typography>
+      <Typography color="text.secondary">계정 및 앱 설정</Typography>
+    </Container>
+  )
+}
+
+function NotFound() {
+  return (
+    <Container>
+      <Box textAlign="center" py={8}>
+        <Typography variant="h1" fontWeight={700} color="primary">
+          404
+        </Typography>
+        <Typography variant="h5" gutterBottom>
+          페이지를 찾을 수 없습니다
+        </Typography>
+        <Button variant="contained" href="/" sx={{ mt: 2 }}>
+          홈으로 돌아가기
+        </Button>
       </Box>
     </Container>
   )
@@ -43,7 +193,20 @@ function Home() {
 function App() {
   return (
     <Routes>
-      <Route path="/" element={<Home />} />
+      {/* MainLayout 적용 라우트 */}
+      <Route element={<MainLayout />}>
+        <Route path="/" element={<Dashboard />} />
+        <Route path="/dashboard" element={<Dashboard />} />
+        <Route path="/interview" element={<InterviewPage />} />
+        <Route path="/opic" element={<OpicPage />} />
+        <Route path="/freetalk" element={<FreetalkPage />} />
+        <Route path="/writing" element={<WritingPage />} />
+        <Route path="/reports" element={<ReportsPage />} />
+        <Route path="/settings" element={<SettingsPage />} />
+      </Route>
+
+      {/* 404 */}
+      <Route path="*" element={<NotFound />} />
     </Routes>
   )
 }

--- a/src/contexts/ThemeContext.jsx
+++ b/src/contexts/ThemeContext.jsx
@@ -1,0 +1,79 @@
+import { createContext, useContext, useState, useEffect, useMemo } from 'react'
+import { ThemeProvider as MuiThemeProvider } from '@mui/material/styles'
+import { CssBaseline } from '@mui/material'
+import { lightTheme, darkTheme } from '../theme/theme'
+
+const ThemeContext = createContext({
+  mode: 'light',
+  toggleTheme: () => {},
+  setMode: () => {},
+})
+
+export const useThemeMode = () => {
+  const context = useContext(ThemeContext)
+  if (!context) {
+    throw new Error('useThemeMode must be used within ThemeProvider')
+  }
+  return context
+}
+
+export const ThemeProvider = ({ children }) => {
+  // localStorage에서 테마 모드 불러오기 (시스템 설정 기본값)
+  const [mode, setMode] = useState(() => {
+    const savedMode = localStorage.getItem('themeMode')
+    if (savedMode) return savedMode
+
+    // 시스템 다크모드 감지
+    if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
+      return 'dark'
+    }
+    return 'light'
+  })
+
+  // 시스템 테마 변경 감지
+  useEffect(() => {
+    const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)')
+    const handleChange = (e) => {
+      const savedMode = localStorage.getItem('themeMode')
+      if (!savedMode) {
+        setMode(e.matches ? 'dark' : 'light')
+      }
+    }
+
+    mediaQuery.addEventListener('change', handleChange)
+    return () => mediaQuery.removeEventListener('change', handleChange)
+  }, [])
+
+  // 테마 변경 시 localStorage 저장
+  useEffect(() => {
+    localStorage.setItem('themeMode', mode)
+    // body 클래스 추가 (CSS 변수 등에서 활용)
+    document.body.classList.remove('light-mode', 'dark-mode')
+    document.body.classList.add(`${mode}-mode`)
+  }, [mode])
+
+  const toggleTheme = () => {
+    setMode((prev) => (prev === 'light' ? 'dark' : 'light'))
+  }
+
+  const theme = useMemo(() => {
+    return mode === 'dark' ? darkTheme : lightTheme
+  }, [mode])
+
+  const contextValue = useMemo(() => ({
+    mode,
+    toggleTheme,
+    setMode,
+  }), [mode])
+
+  return (
+    <ThemeContext.Provider value={contextValue}>
+      <MuiThemeProvider theme={theme}>
+        <CssBaseline />
+        {children}
+      </MuiThemeProvider>
+    </ThemeContext.Provider>
+  )
+}
+
+export default ThemeContext

--- a/src/layouts/MainLayout/Footer/index.jsx
+++ b/src/layouts/MainLayout/Footer/index.jsx
@@ -1,0 +1,71 @@
+import { Box, Typography, Link, Container, Divider } from '@mui/material'
+
+const Footer = () => {
+  return (
+    <Box
+      component="footer"
+      sx={{
+        py: 3,
+        px: 2,
+        mt: 'auto',
+        backgroundColor: 'background.paper',
+        borderTop: 1,
+        borderColor: 'divider',
+      }}
+    >
+      <Container maxWidth="lg">
+        <Box
+          sx={{
+            display: 'flex',
+            flexDirection: { xs: 'column', sm: 'row' },
+            justifyContent: 'space-between',
+            alignItems: { xs: 'center', sm: 'flex-start' },
+            gap: 2,
+          }}
+        >
+          {/* 저작권 */}
+          <Typography variant="body2" color="text.secondary">
+            © 2026 AI Language Learning. All rights reserved.
+          </Typography>
+
+          {/* 링크 */}
+          <Box
+            sx={{
+              display: 'flex',
+              gap: 3,
+              flexWrap: 'wrap',
+              justifyContent: 'center',
+            }}
+          >
+            <Link
+              href="/terms"
+              color="text.secondary"
+              underline="hover"
+              variant="body2"
+            >
+              이용약관
+            </Link>
+            <Link
+              href="/privacy"
+              color="text.secondary"
+              underline="hover"
+              variant="body2"
+            >
+              개인정보처리방침
+            </Link>
+            <Link
+              href="/contact"
+              color="text.secondary"
+              underline="hover"
+              variant="body2"
+            >
+              고객센터
+            </Link>
+          </Box>
+        </Box>
+      </Container>
+    </Box>
+  )
+}
+
+export default Footer

--- a/src/layouts/MainLayout/Header/index.jsx
+++ b/src/layouts/MainLayout/Header/index.jsx
@@ -1,0 +1,256 @@
+import { useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import {
+  AppBar,
+  Toolbar,
+  Typography,
+  IconButton,
+  Box,
+  Button,
+  Avatar,
+  Menu,
+  MenuItem,
+  Divider,
+  Badge,
+  useMediaQuery,
+  useTheme,
+} from '@mui/material'
+import {
+  Menu as MenuIcon,
+  Notifications as NotificationsIcon,
+  Person as PersonIcon,
+  Settings as SettingsIcon,
+  Logout as LogoutIcon,
+  School as SchoolIcon,
+  DarkMode as DarkModeIcon,
+  LightMode as LightModeIcon,
+} from '@mui/icons-material'
+import { useThemeMode } from '../../../contexts/ThemeContext'
+
+const Header = ({ onMenuClick, sidebarOpen }) => {
+  const theme = useTheme()
+  const navigate = useNavigate()
+  const isMobile = useMediaQuery(theme.breakpoints.down('md'))
+  const { mode, toggleTheme } = useThemeMode()
+
+  const [anchorEl, setAnchorEl] = useState(null)
+  const [notificationAnchor, setNotificationAnchor] = useState(null)
+
+  const handleProfileMenuOpen = (event) => {
+    setAnchorEl(event.currentTarget)
+  }
+
+  const handleProfileMenuClose = () => {
+    setAnchorEl(null)
+  }
+
+  const handleNotificationOpen = (event) => {
+    setNotificationAnchor(event.currentTarget)
+  }
+
+  const handleNotificationClose = () => {
+    setNotificationAnchor(null)
+  }
+
+  const handleLogout = () => {
+    handleProfileMenuClose()
+    // TODO: 로그아웃 로직
+    navigate('/login')
+  }
+
+  return (
+    <AppBar
+      position="fixed"
+      sx={{
+        zIndex: theme.zIndex.drawer + 1,
+        backgroundColor: 'primary.main',
+      }}
+    >
+      <Toolbar>
+        {/* 햄버거 메뉴 (모바일/태블릿) */}
+        {isMobile && (
+          <IconButton
+            color="inherit"
+            edge="start"
+            onClick={onMenuClick}
+            sx={{ mr: 2 }}
+          >
+            <MenuIcon />
+          </IconButton>
+        )}
+
+        {/* 로고 & 서비스명 */}
+        <Box
+          sx={{
+            display: 'flex',
+            alignItems: 'center',
+            cursor: 'pointer',
+          }}
+          onClick={() => navigate('/')}
+        >
+          <SchoolIcon sx={{ fontSize: 32, mr: 1 }} />
+          <Typography
+            variant="h6"
+            noWrap
+            sx={{
+              fontWeight: 700,
+              letterSpacing: '-0.5px',
+              display: { xs: 'none', sm: 'block' },
+            }}
+          >
+            AI 언어 학습
+          </Typography>
+        </Box>
+
+        {/* 중앙 네비게이션 (데스크톱) */}
+        {!isMobile && (
+          <Box sx={{ display: 'flex', ml: 4, gap: 1 }}>
+            <Button
+              color="inherit"
+              onClick={() => navigate('/dashboard')}
+              sx={{ fontWeight: 500 }}
+            >
+              대시보드
+            </Button>
+            <Button
+              color="inherit"
+              onClick={() => navigate('/learning')}
+              sx={{ fontWeight: 500 }}
+            >
+              학습 모드
+            </Button>
+            <Button
+              color="inherit"
+              onClick={() => navigate('/reports')}
+              sx={{ fontWeight: 500 }}
+            >
+              리포트
+            </Button>
+          </Box>
+        )}
+
+        <Box sx={{ flexGrow: 1 }} />
+
+        {/* 우측 아이콘들 */}
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+          {/* 다크모드 토글 */}
+          <IconButton
+            color="inherit"
+            onClick={toggleTheme}
+            title={mode === 'dark' ? '라이트 모드로 전환' : '다크 모드로 전환'}
+          >
+            {mode === 'dark' ? <LightModeIcon /> : <DarkModeIcon />}
+          </IconButton>
+
+          {/* 알림 */}
+          <IconButton
+            color="inherit"
+            onClick={handleNotificationOpen}
+          >
+            <Badge badgeContent={3} color="error">
+              <NotificationsIcon />
+            </Badge>
+          </IconButton>
+
+          {/* 프로필 */}
+          <IconButton
+            onClick={handleProfileMenuOpen}
+            sx={{ ml: 1 }}
+          >
+            <Avatar
+              sx={{
+                width: 36,
+                height: 36,
+                bgcolor: 'secondary.main',
+              }}
+            >
+              U
+            </Avatar>
+          </IconButton>
+        </Box>
+
+        {/* 알림 메뉴 */}
+        <Menu
+          anchorEl={notificationAnchor}
+          open={Boolean(notificationAnchor)}
+          onClose={handleNotificationClose}
+          PaperProps={{
+            sx: { width: 320, maxHeight: 400 },
+          }}
+        >
+          <Box sx={{ px: 2, py: 1 }}>
+            <Typography variant="subtitle1" fontWeight={600}>
+              알림
+            </Typography>
+          </Box>
+          <Divider />
+          <MenuItem onClick={handleNotificationClose}>
+            <Box>
+              <Typography variant="body2">
+                면접 연습 세션이 완료되었습니다.
+              </Typography>
+              <Typography variant="caption" color="text.secondary">
+                10분 전
+              </Typography>
+            </Box>
+          </MenuItem>
+          <MenuItem onClick={handleNotificationClose}>
+            <Box>
+              <Typography variant="body2">
+                OPIC 모의고사 결과가 도착했습니다.
+              </Typography>
+              <Typography variant="caption" color="text.secondary">
+                1시간 전
+              </Typography>
+            </Box>
+          </MenuItem>
+          <MenuItem onClick={handleNotificationClose}>
+            <Box>
+              <Typography variant="body2">
+                새로운 학습 리포트가 생성되었습니다.
+              </Typography>
+              <Typography variant="caption" color="text.secondary">
+                어제
+              </Typography>
+            </Box>
+          </MenuItem>
+        </Menu>
+
+        {/* 프로필 메뉴 */}
+        <Menu
+          anchorEl={anchorEl}
+          open={Boolean(anchorEl)}
+          onClose={handleProfileMenuClose}
+          PaperProps={{
+            sx: { width: 200 },
+          }}
+        >
+          <Box sx={{ px: 2, py: 1 }}>
+            <Typography variant="subtitle2" fontWeight={600}>
+              사용자님
+            </Typography>
+            <Typography variant="caption" color="text.secondary">
+              user@example.com
+            </Typography>
+          </Box>
+          <Divider />
+          <MenuItem onClick={() => { handleProfileMenuClose(); navigate('/profile'); }}>
+            <PersonIcon sx={{ mr: 1, fontSize: 20 }} />
+            내 프로필
+          </MenuItem>
+          <MenuItem onClick={() => { handleProfileMenuClose(); navigate('/settings'); }}>
+            <SettingsIcon sx={{ mr: 1, fontSize: 20 }} />
+            설정
+          </MenuItem>
+          <Divider />
+          <MenuItem onClick={handleLogout} sx={{ color: 'error.main' }}>
+            <LogoutIcon sx={{ mr: 1, fontSize: 20 }} />
+            로그아웃
+          </MenuItem>
+        </Menu>
+      </Toolbar>
+    </AppBar>
+  )
+}
+
+export default Header

--- a/src/layouts/MainLayout/Sidebar/index.jsx
+++ b/src/layouts/MainLayout/Sidebar/index.jsx
@@ -1,0 +1,262 @@
+import { useLocation, useNavigate } from 'react-router-dom'
+import {
+  Drawer,
+  Box,
+  List,
+  ListItem,
+  ListItemButton,
+  ListItemIcon,
+  ListItemText,
+  IconButton,
+  Divider,
+  Typography,
+  useTheme,
+  useMediaQuery,
+} from '@mui/material'
+import {
+  ChevronLeft as ChevronLeftIcon,
+  ChevronRight as ChevronRightIcon,
+  Dashboard as DashboardIcon,
+  RecordVoiceOver as InterviewIcon,
+  Headphones as OpicIcon,
+  Chat as FreetalkIcon,
+  Edit as WritingIcon,
+  Assessment as ReportIcon,
+  Settings as SettingsIcon,
+} from '@mui/icons-material'
+
+const DRAWER_WIDTH = 260
+const DRAWER_WIDTH_COLLAPSED = 72
+
+const menuItems = [
+  {
+    category: '학습 모드',
+    items: [
+      {
+        id: 'interview',
+        label: '면접 시뮬레이션',
+        icon: InterviewIcon,
+        path: '/interview',
+        description: 'AI 면접관과 실전 연습'
+      },
+      {
+        id: 'opic',
+        label: 'OPIC 연습',
+        icon: OpicIcon,
+        path: '/opic',
+        description: '레벨별 맞춤 연습'
+      },
+      {
+        id: 'freetalk',
+        label: '프리토킹',
+        icon: FreetalkIcon,
+        path: '/freetalk',
+        description: 'AI와 자유로운 대화'
+      },
+      {
+        id: 'writing',
+        label: '작문 연습',
+        icon: WritingIcon,
+        path: '/writing',
+        description: '문법 교정 & 피드백'
+      },
+    ],
+  },
+  {
+    category: '기타',
+    items: [
+      {
+        id: 'dashboard',
+        label: '대시보드',
+        icon: DashboardIcon,
+        path: '/dashboard',
+        description: '학습 현황 요약'
+      },
+      {
+        id: 'reports',
+        label: '내 리포트',
+        icon: ReportIcon,
+        path: '/reports',
+        description: '학습 결과 분석'
+      },
+      {
+        id: 'settings',
+        label: '설정',
+        icon: SettingsIcon,
+        path: '/settings',
+        description: '계정 및 앱 설정'
+      },
+    ],
+  },
+]
+
+const Sidebar = ({ open, collapsed, onToggleCollapse, onClose }) => {
+  const theme = useTheme()
+  const location = useLocation()
+  const navigate = useNavigate()
+  const isMobile = useMediaQuery(theme.breakpoints.down('md'))
+
+  const drawerWidth = collapsed ? DRAWER_WIDTH_COLLAPSED : DRAWER_WIDTH
+
+  const handleNavigation = (path) => {
+    navigate(path)
+    if (isMobile) {
+      onClose()
+    }
+  }
+
+  const isActive = (path) => location.pathname === path
+
+  const drawerContent = (
+    <Box sx={{ height: '100%', display: 'flex', flexDirection: 'column' }}>
+      {/* 헤더 영역 - Toolbar 높이만큼 여백 */}
+      <Box sx={{ height: 64 }} />
+
+      {/* 접기/펼치기 버튼 */}
+      {!isMobile && (
+        <Box sx={{ display: 'flex', justifyContent: 'flex-end', p: 1 }}>
+          <IconButton onClick={onToggleCollapse} size="small">
+            {collapsed ? <ChevronRightIcon /> : <ChevronLeftIcon />}
+          </IconButton>
+        </Box>
+      )}
+
+      {/* 메뉴 리스트 */}
+      <Box sx={{ flex: 1, overflow: 'auto', px: 1 }}>
+        {menuItems.map((category, categoryIndex) => (
+          <Box key={category.category} sx={{ mb: 2 }}>
+            {!collapsed && (
+              <Typography
+                variant="caption"
+                sx={{
+                  px: 2,
+                  py: 1,
+                  display: 'block',
+                  color: 'text.secondary',
+                  fontWeight: 600,
+                  textTransform: 'uppercase',
+                  letterSpacing: '0.5px',
+                }}
+              >
+                {category.category}
+              </Typography>
+            )}
+
+            <List disablePadding>
+              {category.items.map((item) => {
+                const Icon = item.icon
+                const active = isActive(item.path)
+
+                return (
+                  <ListItem key={item.id} disablePadding sx={{ mb: 0.5 }}>
+                    <ListItemButton
+                      onClick={() => handleNavigation(item.path)}
+                      sx={{
+                        borderRadius: 2,
+                        minHeight: 48,
+                        justifyContent: collapsed ? 'center' : 'flex-start',
+                        px: collapsed ? 1 : 2,
+                        backgroundColor: active ? 'primary.main' : 'transparent',
+                        color: active ? 'white' : 'text.primary',
+                        '&:hover': {
+                          backgroundColor: active
+                            ? 'primary.dark'
+                            : 'action.hover',
+                        },
+                      }}
+                    >
+                      <ListItemIcon
+                        sx={{
+                          minWidth: collapsed ? 0 : 40,
+                          justifyContent: 'center',
+                          color: active ? 'white' : 'primary.main',
+                        }}
+                      >
+                        <Icon />
+                      </ListItemIcon>
+
+                      {!collapsed && (
+                        <ListItemText
+                          primary={item.label}
+                          secondary={item.description}
+                          primaryTypographyProps={{
+                            fontSize: 14,
+                            fontWeight: active ? 600 : 500,
+                          }}
+                          secondaryTypographyProps={{
+                            fontSize: 11,
+                            color: active ? 'rgba(255,255,255,0.7)' : 'text.secondary',
+                          }}
+                        />
+                      )}
+                    </ListItemButton>
+                  </ListItem>
+                )
+              })}
+            </List>
+
+            {categoryIndex < menuItems.length - 1 && !collapsed && (
+              <Divider sx={{ my: 2 }} />
+            )}
+          </Box>
+        ))}
+      </Box>
+
+      {/* 하단 정보 */}
+      {!collapsed && (
+        <Box sx={{ p: 2, borderTop: 1, borderColor: 'divider' }}>
+          <Typography variant="caption" color="text.secondary">
+            오늘의 학습 시간
+          </Typography>
+          <Typography variant="h6" color="primary.main" fontWeight={600}>
+            1시간 23분
+          </Typography>
+        </Box>
+      )}
+    </Box>
+  )
+
+  // 모바일: 임시 Drawer
+  if (isMobile) {
+    return (
+      <Drawer
+        variant="temporary"
+        open={open}
+        onClose={onClose}
+        ModalProps={{ keepMounted: true }}
+        sx={{
+          '& .MuiDrawer-paper': {
+            width: DRAWER_WIDTH,
+            boxSizing: 'border-box',
+          },
+        }}
+      >
+        {drawerContent}
+      </Drawer>
+    )
+  }
+
+  // 데스크톱: 고정 Drawer
+  return (
+    <Drawer
+      variant="permanent"
+      sx={{
+        width: drawerWidth,
+        flexShrink: 0,
+        '& .MuiDrawer-paper': {
+          width: drawerWidth,
+          boxSizing: 'border-box',
+          transition: theme.transitions.create('width', {
+            easing: theme.transitions.easing.sharp,
+            duration: theme.transitions.duration.enteringScreen,
+          }),
+          overflowX: 'hidden',
+        },
+      }}
+    >
+      {drawerContent}
+    </Drawer>
+  )
+}
+
+export default Sidebar

--- a/src/layouts/MainLayout/index.jsx
+++ b/src/layouts/MainLayout/index.jsx
@@ -1,0 +1,95 @@
+import { useState, useEffect } from 'react'
+import { Outlet } from 'react-router-dom'
+import { Box, useTheme, useMediaQuery } from '@mui/material'
+import Header from './Header'
+import Sidebar from './Sidebar'
+import Footer from './Footer'
+
+const DRAWER_WIDTH = 260
+const DRAWER_WIDTH_COLLAPSED = 72
+
+const MainLayout = () => {
+  const theme = useTheme()
+  const isMobile = useMediaQuery(theme.breakpoints.down('md'))
+
+  // 모바일 사이드바 열림 상태
+  const [mobileOpen, setMobileOpen] = useState(false)
+
+  // 데스크톱 사이드바 접힘 상태 (localStorage 저장)
+  const [collapsed, setCollapsed] = useState(() => {
+    const saved = localStorage.getItem('sidebarCollapsed')
+    return saved ? JSON.parse(saved) : false
+  })
+
+  // collapsed 상태 localStorage 저장
+  useEffect(() => {
+    localStorage.setItem('sidebarCollapsed', JSON.stringify(collapsed))
+  }, [collapsed])
+
+  const handleMobileToggle = () => {
+    setMobileOpen(!mobileOpen)
+  }
+
+  const handleMobileClose = () => {
+    setMobileOpen(false)
+  }
+
+  const handleCollapseToggle = () => {
+    setCollapsed(!collapsed)
+  }
+
+  const drawerWidth = isMobile ? 0 : (collapsed ? DRAWER_WIDTH_COLLAPSED : DRAWER_WIDTH)
+
+  return (
+    <Box sx={{ display: 'flex', minHeight: '100vh' }}>
+      {/* Header */}
+      <Header
+        onMenuClick={handleMobileToggle}
+        sidebarOpen={mobileOpen}
+      />
+
+      {/* Sidebar */}
+      <Sidebar
+        open={mobileOpen}
+        collapsed={collapsed}
+        onToggleCollapse={handleCollapseToggle}
+        onClose={handleMobileClose}
+      />
+
+      {/* Main Content */}
+      <Box
+        component="main"
+        sx={{
+          flexGrow: 1,
+          display: 'flex',
+          flexDirection: 'column',
+          minHeight: '100vh',
+          ml: { xs: 0, md: `${drawerWidth}px` },
+          transition: theme.transitions.create('margin', {
+            easing: theme.transitions.easing.sharp,
+            duration: theme.transitions.duration.leavingScreen,
+          }),
+        }}
+      >
+        {/* Toolbar 높이만큼 여백 */}
+        <Box sx={{ height: 64 }} />
+
+        {/* 콘텐츠 영역 */}
+        <Box
+          sx={{
+            flex: 1,
+            p: 3,
+            backgroundColor: 'background.default',
+          }}
+        >
+          <Outlet />
+        </Box>
+
+        {/* Footer */}
+        <Footer />
+      </Box>
+    </Box>
+  )
+}
+
+export default MainLayout

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -2,18 +2,16 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import { Provider } from 'react-redux'
 import { BrowserRouter } from 'react-router-dom'
-import { ThemeProvider, CssBaseline } from '@mui/material'
 import App from './App.jsx'
 import { store } from './store'
-import theme from './theme/theme'
+import { ThemeProvider } from './contexts/ThemeContext'
 import './index.css'
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>
     <Provider store={store}>
       <BrowserRouter>
-        <ThemeProvider theme={theme}>
-          <CssBaseline />
+        <ThemeProvider>
           <App />
         </ThemeProvider>
       </BrowserRouter>

--- a/src/theme/theme.js
+++ b/src/theme/theme.js
@@ -1,7 +1,50 @@
 import { createTheme } from '@mui/material/styles'
 
-const theme = createTheme({
+const baseTheme = {
+  typography: {
+    fontFamily: '"Roboto", "Noto Sans KR", "Helvetica", "Arial", sans-serif',
+    h1: { fontWeight: 700 },
+    h2: { fontWeight: 600 },
+    h3: { fontWeight: 600 },
+    h4: { fontWeight: 600 },
+    h5: { fontWeight: 500 },
+    h6: { fontWeight: 500 },
+  },
+  shape: {
+    borderRadius: 8,
+  },
+  components: {
+    MuiButton: {
+      styleOverrides: {
+        root: {
+          textTransform: 'none',
+          borderRadius: 8,
+          fontWeight: 500,
+        },
+      },
+    },
+    MuiCard: {
+      styleOverrides: {
+        root: {
+          borderRadius: 12,
+        },
+      },
+    },
+    MuiPaper: {
+      styleOverrides: {
+        root: {
+          borderRadius: 12,
+        },
+      },
+    },
+  },
+}
+
+// 라이트 모드
+export const lightTheme = createTheme({
+  ...baseTheme,
   palette: {
+    mode: 'light',
     primary: {
       main: '#0124ac',
       light: '#4a52d4',
@@ -18,36 +61,42 @@ const theme = createTheme({
       default: '#f5f7fa',
       paper: '#ffffff',
     },
-  },
-  typography: {
-    fontFamily: '"Roboto", "Noto Sans KR", "Helvetica", "Arial", sans-serif',
-    h1: {
-      fontWeight: 700,
+    text: {
+      primary: '#1a1a2e',
+      secondary: '#6b7280',
     },
-    h2: {
-      fontWeight: 600,
-    },
-    h3: {
-      fontWeight: 600,
-    },
-  },
-  components: {
-    MuiButton: {
-      styleOverrides: {
-        root: {
-          textTransform: 'none',
-          borderRadius: 8,
-        },
-      },
-    },
-    MuiCard: {
-      styleOverrides: {
-        root: {
-          borderRadius: 12,
-        },
-      },
-    },
+    divider: '#e5e7eb',
   },
 })
 
-export default theme
+// 다크 모드
+export const darkTheme = createTheme({
+  ...baseTheme,
+  palette: {
+    mode: 'dark',
+    primary: {
+      main: '#4a6cf7',
+      light: '#7b93f9',
+      dark: '#2148c4',
+      contrastText: '#ffffff',
+    },
+    secondary: {
+      main: '#64b5f6',
+      light: '#90caf9',
+      dark: '#42a5f5',
+      contrastText: '#000000',
+    },
+    background: {
+      default: '#0f172a',
+      paper: '#1e293b',
+    },
+    text: {
+      primary: '#f1f5f9',
+      secondary: '#94a3b8',
+    },
+    divider: '#334155',
+  },
+})
+
+// 기본 export (하위 호환성)
+export default lightTheme


### PR DESCRIPTION
## 요약
메인 레이아웃 전체 구현

## 변경 사항
- Header: 로고, 네비게이션, 프로필 드롭다운, 알림, 다크모드 토글
- Sidebar: 학습 모드 메뉴, 접기/펼치기, 반응형
- Footer: 저작권 (2026), 링크
- MainLayout: Header + Sidebar + Content + Footer 통합
- ThemeContext: 다크모드 지원 (시스템 설정 감지)
- Dashboard: 학습 모드 카드 UI

## 관련 이슈
Closes #1, #2, #3, #4, #5, #6, #7, #8, #9, #10, #11, #12, #13, #14, #15, #16, #17, #18

## 테스트
- [ ] 라이트/다크 모드 토글 동작 확인
- [ ] 사이드바 접기/펼치기 동작 확인
- [ ] 모바일 반응형 (햄버거 메뉴) 확인
- [ ] 각 메뉴 네비게이션 동작 확인