### PR TITLE
[FIX] 채팅방 카드 고정 크기 적용

### DIFF
--- a/src/domains/freetalk/components/ChatRoomCard.jsx
+++ b/src/domains/freetalk/components/ChatRoomCard.jsx
@@ -19,9 +19,10 @@ const formatTimeAgo = (date) => {
 
 const formatDate = (date) => {
   const d = new Date(date)
-  const month = d.getMonth() + 1
-  const day = d.getDate()
-  return `${month}/${day}`
+  const year = d.getFullYear().toString().slice(2)
+  const month = (d.getMonth() + 1).toString().padStart(2, '0')
+  const day = d.getDate().toString().padStart(2, '0')
+  return `${year}/${month}/${day}`
 }
 
 const ChatRoomCard = ({ room, onClick }) => {


### PR DESCRIPTION
## Summary
채팅방 카드 UI 개선 및 입장 기능 구현

## Changes

### ChatRoomCard UI
- 카드 크기 고정 (300x140px)
- 입장 버튼 추가 (우측 상단, outlined 스타일)
- 비밀방 자물쇠 아이콘 표시
- 간단한 소개 표시
- 생성일 표시 (연/월/일 형식)

### 입장 모달
- 일반방: 방 정보 확인 후 입장
- 비밀방: 비밀번호 입력 후 입장

### 필터
- 참여중 필터 추가 (레벨 필터 옆)

## Modified Files
- `src/domains/freetalk/components/ChatRoomCard.jsx`
- `src/domains/freetalk/pages/FreetalkPeoplePage.jsx`

## Test Plan
- [ ] 채팅방 카드 크기 일정하게 표시 확인
- [ ] 입장 버튼 클릭 시 모달 표시 확인
- [ ] 비밀방 비밀번호 입력 기능 확인
- [ ] 참여중 필터 동작 확인

Closes #31