### PR TITLE
[FIX] 채팅 모달 최소화 후 스크롤 위치 유지 (#55)

### DIFF
--- a/src/domains/freetalk/components/ChatRoomModal.jsx
+++ b/src/domains/freetalk/components/ChatRoomModal.jsx
@@ -202,8 +202,9 @@ const ChatRoomModal = ({ open, onClose, room, onLeave }) => {
       setSavedPosition(position)
       setPosition({ x: 0, y: 0 })
     } else {
-      // 최대화: 저장된 위치로 복원
+      // 최대화: 저장된 위치로 복원 후 스크롤 맨 아래로
       setPosition(savedPosition)
+      setTimeout(() => scrollToBottom(true), 100)
     }
     setMinimized(!minimized)
   }


### PR DESCRIPTION
## Summary
- 채팅 모달 최소화 후 펼칠 때 스크롤이 맨 위로 올라가는 버그 수정
- 펼칠 때 scrollToBottom 호출하여 항상 최신 메시지 위치로 이동

## 수정 파일
- `ChatRoomModal.jsx`: handleToggleMinimize에 scrollToBottom 추가

## Test plan
- [x] 채팅 모달 최소화 후 펼칠 때 스크롤이 맨 아래에 있는지 확인

Closes #55