### PR TITLE
[FEAT] 단어장 (Word List) 기능 구현 (#62)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -35,6 +35,7 @@ import ChatRoomModal from './domains/freetalk/components/ChatRoomModal'
 import VocabDashboard from './domains/vocab/pages/VocabDashboard'
 import DailyLearning from './domains/vocab/pages/DailyLearning'
 import TestPage from './domains/vocab/pages/TestPage'
+import WordListPage from './domains/vocab/pages/WordListPage'
 import { useChat } from './contexts/ChatContext'
 import { useSettings } from './contexts/SettingsContext'
 
@@ -366,6 +367,7 @@ function App() {
           <Route path="/vocab" element={<VocabDashboard />} />
           <Route path="/vocab/daily" element={<DailyLearning />} />
           <Route path="/vocab/test" element={<TestPage />} />
+          <Route path="/vocab/words" element={<WordListPage />} />
           <Route path="/reports" element={<ReportsPage />} />
           <Route path="/settings" element={<SettingsPage />} />
         </Route>

--- a/src/domains/vocab/components/WordDetailModal.jsx
+++ b/src/domains/vocab/components/WordDetailModal.jsx
@@ -1,0 +1,227 @@
+import { useState } from 'react'
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  Box,
+  Typography,
+  IconButton,
+  Chip,
+  Button,
+  ToggleButton,
+  ToggleButtonGroup,
+  Divider,
+} from '@mui/material'
+import {
+  Close as CloseIcon,
+  VolumeUp as VolumeIcon,
+  Star as StarIcon,
+  StarBorder as StarBorderIcon,
+  Favorite as FavoriteIcon,
+  FavoriteBorder as FavoriteBorderIcon,
+} from '@mui/icons-material'
+import {
+  LEVEL_LABELS,
+  LEVEL_COLORS,
+  CATEGORY_LABELS,
+  WORD_STATUS_LABELS,
+  WORD_STATUS_COLORS,
+  DIFFICULTY,
+  DIFFICULTY_LABELS,
+  VOICE_TYPES,
+} from '../constants/vocabConstants'
+
+export default function WordDetailModal({
+  open,
+  onClose,
+  word,
+  userWord,
+  onPlayTTS,
+  onToggleBookmark,
+  onToggleFavorite,
+  onSetDifficulty,
+  isPlayingTTS,
+}) {
+  const [selectedVoice, setSelectedVoice] = useState(VOICE_TYPES.FEMALE)
+
+  if (!word) return null
+
+  const handlePlayTTS = () => {
+    onPlayTTS?.(selectedVoice)
+  }
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
+      <DialogTitle>
+        <Box display="flex" justifyContent="space-between" alignItems="center">
+          <Typography variant="h5" fontWeight={700}>
+            {word.english}
+          </Typography>
+          <IconButton onClick={onClose} size="small">
+            <CloseIcon />
+          </IconButton>
+        </Box>
+      </DialogTitle>
+
+      <DialogContent>
+        {/* TTS */}
+        <Box mb={3}>
+          <Typography variant="body2" color="text.secondary" mb={1}>
+            발음 듣기
+          </Typography>
+          <Box display="flex" alignItems="center" gap={2}>
+            <ToggleButtonGroup
+              value={selectedVoice}
+              exclusive
+              onChange={(e, val) => val && setSelectedVoice(val)}
+              size="small"
+            >
+              <ToggleButton value={VOICE_TYPES.FEMALE}>여성</ToggleButton>
+              <ToggleButton value={VOICE_TYPES.MALE}>남성</ToggleButton>
+            </ToggleButtonGroup>
+            <Button
+              variant="contained"
+              startIcon={<VolumeIcon />}
+              onClick={handlePlayTTS}
+              disabled={isPlayingTTS}
+            >
+              {isPlayingTTS ? '재생 중...' : '듣기'}
+            </Button>
+          </Box>
+        </Box>
+
+        {/* 뜻 */}
+        <Box mb={3}>
+          <Typography variant="h4" fontWeight={600}>
+            {word.korean}
+          </Typography>
+          <Box display="flex" gap={1} mt={1}>
+            <Chip
+              label={LEVEL_LABELS[word.level]}
+              color={LEVEL_COLORS[word.level]}
+              size="small"
+            />
+            <Chip
+              label={CATEGORY_LABELS[word.category]}
+              variant="outlined"
+              size="small"
+            />
+          </Box>
+        </Box>
+
+        {/* 예문 */}
+        {word.example && (
+          <Box mb={3}>
+            <Typography variant="body2" color="text.secondary" mb={0.5}>
+              예문
+            </Typography>
+            <Typography
+              variant="body1"
+              sx={{ fontStyle: 'italic', color: 'text.primary' }}
+            >
+              "{word.example}"
+            </Typography>
+          </Box>
+        )}
+
+        <Divider sx={{ my: 2 }} />
+
+        {/* 학습 현황 */}
+        {userWord && (
+          <Box mb={3}>
+            <Typography variant="body2" color="text.secondary" mb={1}>
+              학습 현황
+            </Typography>
+            <Box
+              sx={{
+                p: 2,
+                backgroundColor: 'grey.50',
+                borderRadius: 2,
+              }}
+            >
+              <Box display="flex" justifyContent="space-between" mb={1}>
+                <Typography variant="body2">정답</Typography>
+                <Typography variant="body2" fontWeight={600} color="success.main">
+                  {userWord.correctCount || 0}회
+                </Typography>
+              </Box>
+              <Box display="flex" justifyContent="space-between" mb={1}>
+                <Typography variant="body2">오답</Typography>
+                <Typography variant="body2" fontWeight={600} color="error.main">
+                  {userWord.incorrectCount || 0}회
+                </Typography>
+              </Box>
+              <Box display="flex" justifyContent="space-between" mb={1}>
+                <Typography variant="body2">정확도</Typography>
+                <Typography variant="body2" fontWeight={600}>
+                  {userWord.correctCount + userWord.incorrectCount > 0
+                    ? (
+                        (userWord.correctCount /
+                          (userWord.correctCount + userWord.incorrectCount)) *
+                        100
+                      ).toFixed(1)
+                    : 0}
+                  %
+                </Typography>
+              </Box>
+              <Box display="flex" justifyContent="space-between" mb={1}>
+                <Typography variant="body2">상태</Typography>
+                <Chip
+                  label={WORD_STATUS_LABELS[userWord.status]}
+                  color={WORD_STATUS_COLORS[userWord.status]}
+                  size="small"
+                />
+              </Box>
+              {userWord.nextReviewAt && (
+                <Box display="flex" justifyContent="space-between">
+                  <Typography variant="body2">다음 복습</Typography>
+                  <Typography variant="body2" fontWeight={600}>
+                    {new Date(userWord.nextReviewAt).toLocaleDateString()}
+                  </Typography>
+                </Box>
+              )}
+            </Box>
+          </Box>
+        )}
+
+        {/* 액션 */}
+        <Box display="flex" alignItems="center" justifyContent="space-between">
+          <Box display="flex" gap={1}>
+            <IconButton onClick={onToggleBookmark}>
+              {userWord?.bookmarked ? (
+                <StarIcon color="warning" />
+              ) : (
+                <StarBorderIcon />
+              )}
+            </IconButton>
+            <IconButton onClick={onToggleFavorite}>
+              {userWord?.favorite ? (
+                <FavoriteIcon color="error" />
+              ) : (
+                <FavoriteBorderIcon />
+              )}
+            </IconButton>
+          </Box>
+
+          <Box>
+            <Typography variant="caption" color="text.secondary" mr={1}>
+              난이도
+            </Typography>
+            <ToggleButtonGroup
+              value={userWord?.difficulty || DIFFICULTY.NORMAL}
+              exclusive
+              onChange={(e, val) => val && onSetDifficulty?.(val)}
+              size="small"
+            >
+              {Object.entries(DIFFICULTY_LABELS).map(([key, label]) => (
+                <ToggleButton key={key} value={key}>
+                  {label}
+                </ToggleButton>
+              ))}
+            </ToggleButtonGroup>
+          </Box>
+        </Box>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/domains/vocab/components/WordListItem.jsx
+++ b/src/domains/vocab/components/WordListItem.jsx
@@ -1,0 +1,118 @@
+import {
+  Box,
+  Typography,
+  IconButton,
+  Chip,
+  ListItem,
+  ListItemText,
+  Tooltip,
+} from '@mui/material'
+import {
+  VolumeUp as VolumeIcon,
+  Star as StarIcon,
+  StarBorder as StarBorderIcon,
+} from '@mui/icons-material'
+import {
+  LEVEL_LABELS,
+  LEVEL_COLORS,
+  CATEGORY_LABELS,
+  WORD_STATUS_LABELS,
+  WORD_STATUS_COLORS,
+} from '../constants/vocabConstants'
+
+export default function WordListItem({
+  word,
+  userWord,
+  onPlayTTS,
+  onToggleBookmark,
+  onClick,
+  isPlayingTTS,
+}) {
+  const status = userWord?.status
+  const bookmarked = userWord?.bookmarked
+
+  return (
+    <ListItem
+      onClick={onClick}
+      sx={{
+        cursor: 'pointer',
+        borderBottom: '1px solid',
+        borderColor: 'divider',
+        py: 1.5,
+        '&:hover': {
+          backgroundColor: 'action.hover',
+        },
+      }}
+    >
+      <ListItemText
+        primary={
+          <Box display="flex" alignItems="center" gap={1}>
+            <Typography variant="body1" fontWeight={600}>
+              {word.english}
+            </Typography>
+            <Chip
+              label={LEVEL_LABELS[word.level]}
+              size="small"
+              color={LEVEL_COLORS[word.level]}
+              sx={{ height: 20, fontSize: 11 }}
+            />
+            <Chip
+              label={CATEGORY_LABELS[word.category]}
+              size="small"
+              variant="outlined"
+              sx={{ height: 20, fontSize: 11 }}
+            />
+          </Box>
+        }
+        secondary={
+          <Box display="flex" alignItems="center" gap={1} mt={0.5}>
+            <Typography variant="body2" color="text.secondary">
+              {word.korean}
+            </Typography>
+            {status && (
+              <Chip
+                label={WORD_STATUS_LABELS[status]}
+                size="small"
+                color={WORD_STATUS_COLORS[status]}
+                sx={{ height: 18, fontSize: 10 }}
+              />
+            )}
+          </Box>
+        }
+      />
+
+      <Box display="flex" alignItems="center" gap={0.5}>
+        <Tooltip title="발음 듣기">
+          <IconButton
+            size="small"
+            onClick={(e) => {
+              e.stopPropagation()
+              onPlayTTS?.()
+            }}
+            disabled={isPlayingTTS}
+          >
+            <VolumeIcon
+              fontSize="small"
+              color={isPlayingTTS ? 'primary' : 'action'}
+            />
+          </IconButton>
+        </Tooltip>
+        <Tooltip title={bookmarked ? '북마크 해제' : '북마크'}>
+          <IconButton
+            size="small"
+            onClick={(e) => {
+              e.stopPropagation()
+              onToggleBookmark?.()
+            }}
+          >
+            {bookmarked ? (
+              <StarIcon fontSize="small" color="warning" />
+            ) : (
+              <StarBorderIcon fontSize="small" />
+            )}
+          </IconButton>
+        </Tooltip>
+      </Box>
+    </ListItem>
+  )
+}

--- a/src/domains/vocab/pages/WordListPage.jsx
+++ b/src/domains/vocab/pages/WordListPage.jsx
@@ -1,0 +1,485 @@
+import { useState, useEffect, useCallback, useRef } from 'react'
+import { useNavigate } from 'react-router-dom'
+import {
+  Container,
+  Box,
+  Typography,
+  TextField,
+  InputAdornment,
+  IconButton,
+  Chip,
+  List,
+  CircularProgress,
+  Alert,
+  Paper,
+  ToggleButton,
+  ToggleButtonGroup,
+  Menu,
+  MenuItem,
+} from '@mui/material'
+import {
+  ArrowBack as BackIcon,
+  Search as SearchIcon,
+  Clear as ClearIcon,
+  FilterList as FilterIcon,
+  Star as StarIcon,
+} from '@mui/icons-material'
+import WordListItem from '../components/WordListItem'
+import WordDetailModal from '../components/WordDetailModal'
+import { wordService, userWordService, voiceService } from '../services/vocabService'
+import {
+  LEVELS,
+  LEVEL_LABELS,
+  CATEGORIES,
+  CATEGORY_LABELS,
+  WORD_STATUS,
+  WORD_STATUS_LABELS,
+  VOICE_TYPES,
+} from '../constants/vocabConstants'
+
+const TEMP_USER_ID = import.meta.env.VITE_TEMP_USER_ID || 'user1'
+const PAGE_SIZE = 20
+
+// 디바운스 훅
+function useDebounce(value, delay) {
+  const [debouncedValue, setDebouncedValue] = useState(value)
+
+  useEffect(() => {
+    const timer = setTimeout(() => setDebouncedValue(value), delay)
+    return () => clearTimeout(timer)
+  }, [value, delay])
+
+  return debouncedValue
+}
+
+export default function WordListPage() {
+  const navigate = useNavigate()
+  const observerRef = useRef(null)
+  const loadMoreRef = useRef(null)
+
+  // 검색 & 필터
+  const [searchText, setSearchText] = useState('')
+  const [levelFilter, setLevelFilter] = useState(null)
+  const [categoryFilter, setCategoryFilter] = useState(null)
+  const [statusFilter, setStatusFilter] = useState(null)
+  const [bookmarkedOnly, setBookmarkedOnly] = useState(false)
+
+  // 필터 메뉴
+  const [categoryAnchor, setCategoryAnchor] = useState(null)
+  const [statusAnchor, setStatusAnchor] = useState(null)
+
+  // 단어 데이터
+  const [words, setWords] = useState([])
+  const [userWords, setUserWords] = useState({})
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState(null)
+  const [hasMore, setHasMore] = useState(true)
+  const [page, setPage] = useState(0)
+
+  // 상세 모달
+  const [selectedWord, setSelectedWord] = useState(null)
+  const [modalOpen, setModalOpen] = useState(false)
+
+  // TTS
+  const [playingWordId, setPlayingWordId] = useState(null)
+
+  const debouncedSearch = useDebounce(searchText, 300)
+
+  // 단어 목록 조회
+  const fetchWords = useCallback(async (pageNum, reset = false) => {
+    if (loading) return
+
+    try {
+      setLoading(true)
+      setError(null)
+
+      const params = {
+        page: pageNum,
+        size: PAGE_SIZE,
+      }
+
+      if (debouncedSearch) params.keyword = debouncedSearch
+      if (levelFilter) params.level = levelFilter
+      if (categoryFilter) params.category = categoryFilter
+
+      const response = await wordService.getWords(params)
+      const newWords = response?.data?.words || []
+
+      // 사용자 단어 정보 조회
+      const wordIds = newWords.map(w => w.wordId)
+      if (wordIds.length > 0) {
+        try {
+          const userWordResponse = await userWordService.getUserWords(TEMP_USER_ID, {
+            wordIds: wordIds.join(','),
+          })
+          const userWordMap = {}
+          ;(userWordResponse?.data?.userWords || []).forEach(uw => {
+            userWordMap[uw.wordId] = uw
+          })
+          setUserWords(prev => reset ? userWordMap : { ...prev, ...userWordMap })
+        } catch (err) {
+          console.error('User words fetch error:', err)
+        }
+      }
+
+      // 필터링 (bookmarked, status는 클라이언트에서 처리)
+      let filteredWords = newWords
+
+      setWords(prev => reset ? filteredWords : [...prev, ...filteredWords])
+      setHasMore(newWords.length === PAGE_SIZE)
+      setPage(pageNum)
+    } catch (err) {
+      console.error('Fetch words error:', err)
+      setError('단어 목록을 불러오는데 실패했습니다.')
+    } finally {
+      setLoading(false)
+    }
+  }, [loading, debouncedSearch, levelFilter, categoryFilter])
+
+  // 필터 변경시 리셋
+  useEffect(() => {
+    setWords([])
+    setUserWords({})
+    setPage(0)
+    setHasMore(true)
+    fetchWords(0, true)
+  }, [debouncedSearch, levelFilter, categoryFilter])
+
+  // 무한 스크롤
+  useEffect(() => {
+    if (loading || !hasMore) return
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries[0].isIntersecting && hasMore && !loading) {
+          fetchWords(page + 1)
+        }
+      },
+      { threshold: 0.1 }
+    )
+
+    if (loadMoreRef.current) {
+      observer.observe(loadMoreRef.current)
+    }
+
+    observerRef.current = observer
+
+    return () => {
+      if (observerRef.current) {
+        observerRef.current.disconnect()
+      }
+    }
+  }, [hasMore, loading, page, fetchWords])
+
+  // 클라이언트 필터링 (북마크, 상태)
+  const filteredWords = words.filter(word => {
+    const userWord = userWords[word.wordId]
+
+    if (bookmarkedOnly && !userWord?.bookmarked) return false
+    if (statusFilter && userWord?.status !== statusFilter) return false
+
+    return true
+  })
+
+  // TTS 재생
+  const handlePlayTTS = async (word, voice = VOICE_TYPES.FEMALE) => {
+    if (playingWordId) return
+
+    try {
+      setPlayingWordId(word.wordId)
+      const response = await voiceService.synthesize({
+        text: word.english,
+        voiceType: voice,
+      })
+
+      if (response?.data?.audioUrl) {
+        const audio = new Audio(response.data.audioUrl)
+        audio.onended = () => setPlayingWordId(null)
+        audio.onerror = () => setPlayingWordId(null)
+        await audio.play()
+      } else {
+        setPlayingWordId(null)
+      }
+    } catch (err) {
+      console.error('TTS error:', err)
+      setPlayingWordId(null)
+    }
+  }
+
+  // 북마크 토글
+  const handleToggleBookmark = async (word) => {
+    const userWord = userWords[word.wordId]
+    const newBookmarked = !userWord?.bookmarked
+
+    try {
+      await userWordService.updateUserWord(TEMP_USER_ID, word.wordId, {
+        bookmarked: newBookmarked,
+      })
+
+      setUserWords(prev => ({
+        ...prev,
+        [word.wordId]: {
+          ...prev[word.wordId],
+          bookmarked: newBookmarked,
+        },
+      }))
+    } catch (err) {
+      console.error('Bookmark toggle error:', err)
+    }
+  }
+
+  // 즐겨찾기 토글
+  const handleToggleFavorite = async (word) => {
+    const userWord = userWords[word.wordId]
+    const newFavorite = !userWord?.favorite
+
+    try {
+      await userWordService.updateUserWord(TEMP_USER_ID, word.wordId, {
+        favorite: newFavorite,
+      })
+
+      setUserWords(prev => ({
+        ...prev,
+        [word.wordId]: {
+          ...prev[word.wordId],
+          favorite: newFavorite,
+        },
+      }))
+    } catch (err) {
+      console.error('Favorite toggle error:', err)
+    }
+  }
+
+  // 난이도 설정
+  const handleSetDifficulty = async (word, difficulty) => {
+    try {
+      await userWordService.updateUserWord(TEMP_USER_ID, word.wordId, {
+        difficulty,
+      })
+
+      setUserWords(prev => ({
+        ...prev,
+        [word.wordId]: {
+          ...prev[word.wordId],
+          difficulty,
+        },
+      }))
+    } catch (err) {
+      console.error('Set difficulty error:', err)
+    }
+  }
+
+  // 단어 상세 열기
+  const handleWordClick = (word) => {
+    setSelectedWord(word)
+    setModalOpen(true)
+  }
+
+  // 검색 초기화
+  const handleClearSearch = () => {
+    setSearchText('')
+  }
+
+  // 필터 초기화
+  const handleClearFilters = () => {
+    setLevelFilter(null)
+    setCategoryFilter(null)
+    setStatusFilter(null)
+    setBookmarkedOnly(false)
+  }
+
+  const hasActiveFilters = levelFilter || categoryFilter || statusFilter || bookmarkedOnly
+
+  return (
+    <Container maxWidth="sm" sx={{ pb: 4 }}>
+      {/* 헤더 */}
+      <Box display="flex" alignItems="center" gap={1} py={2}>
+        <IconButton onClick={() => navigate('/vocab')}>
+          <BackIcon />
+        </IconButton>
+        <Typography variant="h5" fontWeight={700}>
+          단어장
+        </Typography>
+      </Box>
+
+      {/* 검색 */}
+      <TextField
+        fullWidth
+        placeholder="단어 검색..."
+        value={searchText}
+        onChange={(e) => setSearchText(e.target.value)}
+        InputProps={{
+          startAdornment: (
+            <InputAdornment position="start">
+              <SearchIcon color="action" />
+            </InputAdornment>
+          ),
+          endAdornment: searchText && (
+            <InputAdornment position="end">
+              <IconButton size="small" onClick={handleClearSearch}>
+                <ClearIcon fontSize="small" />
+              </IconButton>
+            </InputAdornment>
+          ),
+        }}
+        sx={{ mb: 2 }}
+      />
+
+      {/* 필터 */}
+      <Paper sx={{ p: 2, mb: 2 }}>
+        {/* 레벨 필터 */}
+        <Box mb={2}>
+          <Typography variant="caption" color="text.secondary" mb={0.5} display="block">
+            레벨
+          </Typography>
+          <ToggleButtonGroup
+            value={levelFilter}
+            exclusive
+            onChange={(e, val) => setLevelFilter(val)}
+            size="small"
+            fullWidth
+          >
+            <ToggleButton value={null}>전체</ToggleButton>
+            {Object.entries(LEVEL_LABELS).map(([key, label]) => (
+              <ToggleButton key={key} value={key}>
+                {label}
+              </ToggleButton>
+            ))}
+          </ToggleButtonGroup>
+        </Box>
+
+        {/* 추가 필터 */}
+        <Box display="flex" gap={1} flexWrap="wrap">
+          {/* 카테고리 */}
+          <Chip
+            label={categoryFilter ? CATEGORY_LABELS[categoryFilter] : '카테고리'}
+            onClick={(e) => setCategoryAnchor(e.currentTarget)}
+            onDelete={categoryFilter ? () => setCategoryFilter(null) : undefined}
+            variant={categoryFilter ? 'filled' : 'outlined'}
+            size="small"
+          />
+          <Menu
+            anchorEl={categoryAnchor}
+            open={Boolean(categoryAnchor)}
+            onClose={() => setCategoryAnchor(null)}
+          >
+            <MenuItem onClick={() => { setCategoryFilter(null); setCategoryAnchor(null) }}>
+              전체
+            </MenuItem>
+            {Object.entries(CATEGORY_LABELS).map(([key, label]) => (
+              <MenuItem
+                key={key}
+                onClick={() => { setCategoryFilter(key); setCategoryAnchor(null) }}
+                selected={categoryFilter === key}
+              >
+                {label}
+              </MenuItem>
+            ))}
+          </Menu>
+
+          {/* 학습 상태 */}
+          <Chip
+            label={statusFilter ? WORD_STATUS_LABELS[statusFilter] : '학습 상태'}
+            onClick={(e) => setStatusAnchor(e.currentTarget)}
+            onDelete={statusFilter ? () => setStatusFilter(null) : undefined}
+            variant={statusFilter ? 'filled' : 'outlined'}
+            size="small"
+          />
+          <Menu
+            anchorEl={statusAnchor}
+            open={Boolean(statusAnchor)}
+            onClose={() => setStatusAnchor(null)}
+          >
+            <MenuItem onClick={() => { setStatusFilter(null); setStatusAnchor(null) }}>
+              전체
+            </MenuItem>
+            {Object.entries(WORD_STATUS_LABELS).map(([key, label]) => (
+              <MenuItem
+                key={key}
+                onClick={() => { setStatusFilter(key); setStatusAnchor(null) }}
+                selected={statusFilter === key}
+              >
+                {label}
+              </MenuItem>
+            ))}
+          </Menu>
+
+          {/* 북마크 */}
+          <Chip
+            icon={<StarIcon fontSize="small" />}
+            label="북마크"
+            onClick={() => setBookmarkedOnly(!bookmarkedOnly)}
+            color={bookmarkedOnly ? 'warning' : 'default'}
+            variant={bookmarkedOnly ? 'filled' : 'outlined'}
+            size="small"
+          />
+
+          {/* 필터 초기화 */}
+          {hasActiveFilters && (
+            <Chip
+              label="초기화"
+              onClick={handleClearFilters}
+              size="small"
+              color="error"
+              variant="outlined"
+            />
+          )}
+        </Box>
+      </Paper>
+
+      {/* 결과 카운트 */}
+      <Typography variant="body2" color="text.secondary" mb={1}>
+        {filteredWords.length}개의 단어
+      </Typography>
+
+      {error && (
+        <Alert severity="error" sx={{ mb: 2 }} onClose={() => setError(null)}>
+          {error}
+        </Alert>
+      )}
+
+      {/* 단어 목록 */}
+      <List disablePadding>
+        {filteredWords.map((word) => (
+          <WordListItem
+            key={word.wordId}
+            word={word}
+            userWord={userWords[word.wordId]}
+            onPlayTTS={() => handlePlayTTS(word)}
+            onToggleBookmark={() => handleToggleBookmark(word)}
+            onClick={() => handleWordClick(word)}
+            isPlayingTTS={playingWordId === word.wordId}
+          />
+        ))}
+      </List>
+
+      {/* 로딩 & 더보기 트리거 */}
+      <Box ref={loadMoreRef} display="flex" justifyContent="center" py={3}>
+        {loading && <CircularProgress size={32} />}
+        {!loading && !hasMore && filteredWords.length > 0 && (
+          <Typography variant="body2" color="text.secondary">
+            모든 단어를 불러왔습니다
+          </Typography>
+        )}
+        {!loading && filteredWords.length === 0 && !error && (
+          <Typography variant="body2" color="text.secondary">
+            검색 결과가 없습니다
+          </Typography>
+        )}
+      </Box>
+
+      {/* 상세 모달 */}
+      <WordDetailModal
+        open={modalOpen}
+        onClose={() => setModalOpen(false)}
+        word={selectedWord}
+        userWord={selectedWord ? userWords[selectedWord.wordId] : null}
+        onPlayTTS={(voice) => selectedWord && handlePlayTTS(selectedWord, voice)}
+        onToggleBookmark={() => selectedWord && handleToggleBookmark(selectedWord)}
+        onToggleFavorite={() => selectedWord && handleToggleFavorite(selectedWord)}
+        onSetDifficulty={(diff) => selectedWord && handleSetDifficulty(selectedWord, diff)}
+        isPlayingTTS={playingWordId === selectedWord?.wordId}
+      />
+    </Container>
+  )
+}


### PR DESCRIPTION
## Summary
- WordListPage 컴포넌트 구현 (검색, 필터, 무한 스크롤)
- WordListItem 단어 목록 아이템 컴포넌트
- WordDetailModal 단어 상세 모달 (TTS, 북마크, 즐겨찾기, 난이도)
- 검색 입력 디바운스 (300ms) 적용
- 레벨/카테고리/상태/북마크 필터 기능
- Intersection Observer 기반 무한 스크롤
- /vocab/words 라우트 추가

## Test plan
- [ ] /vocab/words 접속 확인
- [ ] 단어 검색 기능 테스트 (디바운스 동작 확인)
- [ ] 레벨/카테고리/상태/북마크 필터 동작 확인
- [ ] 스크롤 시 추가 데이터 로딩 확인
- [ ] 단어 클릭 시 상세 모달 표시 확인
- [ ] TTS 재생 기능 테스트
- [ ] 북마크/즐겨찾기/난이도 설정 기능 테스트

Closes #62, #87, #88, #89, #90, #91, #92