### PR TITLE
fix(freetalk): 채팅방 투명도 시각적 반영 수정

### DIFF
--- a/src/domains/freetalk/components/ChatRoomModal.jsx
+++ b/src/domains/freetalk/components/ChatRoomModal.jsx
@@ -312,6 +312,7 @@ const ChatRoomModal = ({open, onClose, room, onLeave}) => {
                     cursor: isDragging ? 'grabbing' : 'default',
                     border: isDark ? '1px solid rgba(255,255,255,0.1)' : 'none',
                     opacity: opacity / 100,
+                    transition: 'opacity 0.2s ease',
                     pointerEvents: opacity < 50 ? 'none' : 'auto',
                 }}
             >


### PR DESCRIPTION
## 수정 내용
- 메시지 영역 배경색을 rgba로 변경하여 투명도 조절 시 시각적으로 반영되도록 수정
- transition 추가로 부드러운 투명도 변경

Closes #150