### PR TITLE
feat(freetalk): 채팅방 투명도 조절 기능 구현

### DIFF
--- a/src/domains/freetalk/components/ChatRoomModal.jsx
+++ b/src/domains/freetalk/components/ChatRoomModal.jsx
@@ -296,6 +296,7 @@ const ChatRoomModal = ({open, onClose, room, onLeave}) => {
             <Paper
                 ref={dragRef}
                 elevation={8}
+                style={{opacity: opacity / 100}}
                 sx={{
                     position: 'fixed',
                     bottom: position.y || 20,
@@ -311,8 +312,6 @@ const ChatRoomModal = ({open, onClose, room, onLeave}) => {
                     zIndex: 1300,
                     cursor: isDragging ? 'grabbing' : 'default',
                     border: isDark ? '1px solid rgba(255,255,255,0.1)' : 'none',
-                    opacity: opacity / 100,
-                    transition: 'opacity 0.2s ease',
                     pointerEvents: opacity < 50 ? 'none' : 'auto',
                 }}
             >


### PR DESCRIPTION
## 작업 내용
- 채팅방 헤더에 투명도 조절 버튼 추가
- Popover + Slider로 투명도(10~100%) 조절
- 투명도 50% 이하 시 채팅창 뒤 요소 클릭 가능 (pointer-events)
- 헤더/입력창은 항상 조작 가능

Closes #150
Closes #151