### PR TITLE
[FIX] 채팅 메시지 중복 표시 버그 수정

### DIFF
--- a/src/domains/freetalk/hooks/useChatWebSocket.js
+++ b/src/domains/freetalk/hooks/useChatWebSocket.js
@@ -180,6 +180,7 @@ export function useChatWebSocket(roomId, userId) {
 
     /**
      * 메시지 전송
+     * - optimistic update 제거: 서버 브로드캐스트만 표시하여 중복 방지
      */
     const sendMessage = useCallback((content, messageType = 'TEXT') => {
         if (!isConnectedRef.current) {
@@ -187,24 +188,8 @@ export function useChatWebSocket(roomId, userId) {
             return false
         }
 
-        const success = chatWebSocketService.sendMessage(content, messageType)
-
-        if (success) {
-            // Optimistic update - 자신의 메시지 즉시 추가
-            const optimisticMessage = {
-                id: `temp-${Date.now()}`,
-                content,
-                userId,
-                messageType,
-                createdAt: new Date().toISOString(),
-                isOwn: true,
-                isPending: true,
-            }
-            setMessages((prev) => [...prev, optimisticMessage])
-        }
-
-        return success
-    }, [userId])
+        return chatWebSocketService.sendMessage(content, messageType)
+    }, [])
 
     /**
      * 게임 시작


### PR DESCRIPTION
## Summary
채팅 메시지가 두 번 표시되는 버그 수정

## Problem
- 메시지 전송 시 optimistic update로 즉시 추가
- 서버 브로드캐스트로 같은 메시지가 다시 도착하여 중복 표시

## Solution
- optimistic update 제거
- 서버 브로드캐스트만 표시하여 중복 방지

## Files Changed
- `src/domains/freetalk/hooks/useChatWebSocket.js`

## Test plan
- [x] 메시지 전송 시 한 번만 표시됨 확인
