### PR TITLE
[FIX] 캐치마인드 게임 라운드 전환 및 WebSocket 이벤트 처리 개선

### DIFF
--- a/src/domains/freetalk/components/ChatRoomModal.jsx
+++ b/src/domains/freetalk/components/ChatRoomModal.jsx
@@ -58,13 +58,21 @@ const ChatRoomModal = ({open, onClose, room, onLeave}) => {
         messages,
         gameState: wsGameState,
         error: wsError,
+        receivedDrawing,
+        shouldClearCanvas,
+        correctAnswerBubble,
         connect: wsConnect,
         disconnect: wsDisconnect,
         sendMessage: wsSendMessage,
         startGame: wsStartGame,
         stopGame: wsStopGame,
+        sendDrawing: wsSendDrawing,
+        clearDrawing: wsClearDrawing,
         clearError: wsClearError,
         setMessages,
+        setReceivedDrawing,
+        setShouldClearCanvas,
+        setCorrectAnswerBubble,
     } = useChatWebSocket(room?.id, currentUserId)
 
     const [newMessage, setNewMessage] = useState('')
@@ -126,19 +134,20 @@ const ChatRoomModal = ({open, onClose, room, onLeave}) => {
         }
     }, [wsError])
 
-    // WebSocket 게임 상태 변경 감지 - 탭 자동 전환
+    // WebSocket 게임 상태 변경 감지 - 게임 시작 시만 게임 탭으로 전환
     useEffect(() => {
         if (wsGameState?.status === 'PLAYING') {
             setGameStatus(GAME_STATUS.PLAYING)
-            setActiveTab(1)
+            setActiveTab(1) // 게임 시작 시 게임 탭으로 전환
         } else if (wsGameState?.status === 'FINISHED') {
             setGameStatus(GAME_STATUS.NONE)
-            setActiveTab(0)
+            // 게임 종료 시에는 탭 유지 (사용자가 직접 전환하도록)
         }
     }, [wsGameState?.status])
 
     // 초기 로드
     useEffect(() => {
+        console.log('[ChatRoomModal] useEffect triggered:', {open, roomId: room?.id, currentUserId})
         if (open && room?.id && currentUserId) {
             console.log('[ChatRoomModal] Initializing...', {roomId: room.id, userId: currentUserId})
             setLoading(true)
@@ -518,8 +527,20 @@ const ChatRoomModal = ({open, onClose, room, onLeave}) => {
                                     roomId={room?.id}
                                     onGameMessage={handleGameMessage}
                                     initialGameStatus={gameStatus}
+                                    wsGameState={wsGameState}
+                                    isConnected={isConnected}
+                                    messages={messages}
                                     onStartGame={wsStartGame}
                                     onStopGame={wsStopGame}
+                                    onSendMessage={wsSendMessage}
+                                    onSendDrawing={wsSendDrawing}
+                                    onClearDrawing={wsClearDrawing}
+                                    receivedDrawing={receivedDrawing}
+                                    onDrawingProcessed={() => setReceivedDrawing(null)}
+                                    shouldClearCanvas={shouldClearCanvas}
+                                    onCanvasCleared={() => setShouldClearCanvas(false)}
+                                    correctAnswerBubble={correctAnswerBubble}
+                                    onBubbleProcessed={() => setCorrectAnswerBubble(null)}
                                 />
                             </Box>
                         )}

--- a/src/domains/freetalk/components/GameModePanel.jsx
+++ b/src/domains/freetalk/components/GameModePanel.jsx
@@ -15,7 +15,7 @@ import {DESIGN_TOKENS} from '../../../theme/theme'
 const CANVAS_WIDTH = 340
 const CANVAS_HEIGHT = 200
 
-const GameModePanel = ({roomId, onGameMessage, initialGameStatus, onStartGame, onStopGame}) => {
+const GameModePanel = ({roomId, onGameMessage, initialGameStatus, wsGameState, isConnected, onStartGame, onStopGame, onSendMessage, onSendDrawing, onClearDrawing, receivedDrawing, onDrawingProcessed, shouldClearCanvas, onCanvasCleared, messages, correctAnswerBubble, onBubbleProcessed}) => {
     const theme = useTheme()
     const isDark = theme.palette.mode === 'dark'
     const {user} = useAuth()
@@ -37,9 +37,30 @@ const GameModePanel = ({roomId, onGameMessage, initialGameStatus, onStartGame, o
     const [brushColor, setBrushColor] = useState('#000000')
     const [brushSize, setBrushSize] = useState(3)
     const [loading, setLoading] = useState(false)
+    const [currentStroke, setCurrentStroke] = useState([]) // 현재 그리는 스트로크
+    const [bubbles, setBubbles] = useState([]) // 비눗방울 애니메이션
 
     const isDrawer = gameState.currentDrawerId === currentUserId
     const isGameActive = gameState.gameStatus === GAME_STATUS.PLAYING
+
+    // 최신 값을 interval에서 사용하기 위한 ref
+    const isDrawerRef = useRef(isDrawer)
+    const isConnectedRef = useRef(isConnected)
+    const onSendMessageRef = useRef(onSendMessage)
+    useEffect(() => {
+        isDrawerRef.current = isDrawer
+        isConnectedRef.current = isConnected
+        onSendMessageRef.current = onSendMessage
+    }, [isDrawer, isConnected, onSendMessage])
+
+    // 디버깅 로그
+    console.log('[GameModePanel] State:', {
+        isDrawer,
+        isGameActive,
+        currentDrawerId: gameState.currentDrawerId,
+        currentUserId,
+        gameStatus: gameState.gameStatus
+    })
 
     // 게임 상태 조회
     const fetchGameStatus = useCallback(async () => {
@@ -73,17 +94,48 @@ const GameModePanel = ({roomId, onGameMessage, initialGameStatus, onStartGame, o
         }
     }, [initialGameStatus])
 
-    // 타이머
+    // WebSocket 게임 상태 동기화 (제시어, 출제자, 라운드 등)
+    useEffect(() => {
+        if (wsGameState) {
+            console.log('[GameModePanel] Syncing wsGameState:', wsGameState)
+            setGameState(prev => ({
+                ...prev,
+                gameStatus: wsGameState.status === 'PLAYING' ? GAME_STATUS.PLAYING :
+                           wsGameState.status === 'FINISHED' ? GAME_STATUS.NONE : prev.gameStatus,
+                currentRound: wsGameState.currentRound ?? prev.currentRound,
+                totalRounds: wsGameState.totalRounds ?? prev.totalRounds,
+                currentDrawerId: wsGameState.currentDrawerId ?? prev.currentDrawerId,
+                currentWord: wsGameState.currentWord ?? prev.currentWord,
+                roundStartTime: wsGameState.roundStartTime ?? prev.roundStartTime,
+                scores: wsGameState.scores ?? prev.scores,
+                hintUsed: wsGameState.hintUsed ?? prev.hintUsed,
+                hint: wsGameState.hint ?? prev.hint,
+            }))
+        }
+    }, [wsGameState])
+
+    // 타이머 + 자동 스킵 (출제자만)
+    const autoSkipSentRef = useRef(false)
     useEffect(() => {
         if (!isGameActive || !gameState.roundStartTime) return
+
+        // 새 라운드 시작 시 autoSkip 플래그 초기화
+        autoSkipSentRef.current = false
 
         const interval = setInterval(() => {
             const elapsed = Math.floor((Date.now() - gameState.roundStartTime) / 1000)
             const remaining = Math.max(0, gameState.roundTimeLimit - elapsed)
             setTimeLeft(remaining)
 
-            if (remaining === 0) {
-                // 시간 초과 처리
+            // 시간 초과 시 자동 스킵 (출제자만, 연결된 경우만, 한 번만 전송)
+            // ref를 사용해서 최신 값 확인
+            if (remaining === 0 && isDrawerRef.current && isConnectedRef.current && !autoSkipSentRef.current && onSendMessageRef.current) {
+                console.log('[GameModePanel] Time expired, auto-skipping... isDrawer:', isDrawerRef.current, 'isConnected:', isConnectedRef.current)
+                autoSkipSentRef.current = true
+                onSendMessageRef.current('/skip', 'TEXT')
+                clearInterval(interval)
+            } else if (remaining === 0) {
+                console.log('[GameModePanel] Time expired, but cannot skip. isDrawer:', isDrawerRef.current, 'isConnected:', isConnectedRef.current)
                 clearInterval(interval)
             }
         }, 1000)
@@ -93,9 +145,11 @@ const GameModePanel = ({roomId, onGameMessage, initialGameStatus, onStartGame, o
 
     // 게임 시작 - WebSocket을 통해 /start 명령어 전송 (서버에서 인원 검증)
     const handleStartGame = () => {
+        console.log('[GameModePanel] handleStartGame called, onStartGame:', !!onStartGame)
         if (onStartGame) {
             // WebSocket으로 /start 명령어 전송 (채팅창에서 /start 입력과 동일)
-            onStartGame()
+            const result = onStartGame()
+            console.log('[GameModePanel] onStartGame result:', result)
         } else {
             // fallback: REST API 사용 (WebSocket 미연결 시)
             setLoading(true)
@@ -179,28 +233,57 @@ const GameModePanel = ({roomId, onGameMessage, initialGameStatus, onStartGame, o
     }
 
     // 캔버스 초기화
-    const clearCanvas = () => {
+    const clearCanvas = (sendToOthers = false) => {
         const canvas = canvasRef.current
         if (!canvas) return
         const ctx = canvas.getContext('2d')
         ctx.fillStyle = '#ffffff'
         ctx.fillRect(0, 0, canvas.width, canvas.height)
+
+        // 다른 사용자에게도 초기화 메시지 전송
+        if (sendToOthers && onClearDrawing) {
+            onClearDrawing()
+        }
     }
 
-    // 캔버스 드로잉
+    // 캔버스 드로잉 - 스트로크 배열 방식
     const startDrawing = (e) => {
         if (!isDrawer) return
+        const canvas = canvasRef.current
+        if (!canvas) return
+
+        const rect = canvas.getBoundingClientRect()
+        const x = e.clientX - rect.left
+        const y = e.clientY - rect.top
+
         setIsDrawing(true)
-        draw(e)
+        // 스트로크 시작
+        setCurrentStroke([{x, y, type: 'start', color: brushColor, width: brushSize}])
+
+        const ctx = canvas.getContext('2d')
+        ctx.beginPath()
+        ctx.moveTo(x, y)
     }
 
     const stopDrawing = () => {
+        if (!isDrawing) return
         setIsDrawing(false)
+
         const canvas = canvasRef.current
         if (canvas) {
             const ctx = canvas.getContext('2d')
             ctx.beginPath()
         }
+
+        // 스트로크 완료 시 WebSocket으로 전송
+        if (currentStroke.length > 0 && onSendDrawing) {
+            const strokeData = [...currentStroke, {type: 'end'}]
+            console.log('[GameModePanel] Sending stroke:', strokeData)
+            onSendDrawing(JSON.stringify(strokeData))
+        } else {
+            console.log('[GameModePanel] Not sending:', {strokeLength: currentStroke.length, hasOnSendDrawing: !!onSendDrawing})
+        }
+        setCurrentStroke([])
     }
 
     const draw = (e) => {
@@ -220,14 +303,125 @@ const GameModePanel = ({roomId, onGameMessage, initialGameStatus, onStartGame, o
         ctx.stroke()
         ctx.beginPath()
         ctx.moveTo(x, y)
+
+        // 스트로크에 좌표 추가
+        setCurrentStroke(prev => [...prev, {x, y, type: 'move'}])
     }
 
-    // 캔버스 초기화
+    // 캔버스 초기화 (라운드 변경 시)
     useEffect(() => {
         if (canvasRef.current) {
             clearCanvas()
         }
     }, [gameState.currentRound])
+
+    // 원격 캔버스 초기화 (다른 사용자가 초기화 시)
+    useEffect(() => {
+        if (shouldClearCanvas && canvasRef.current) {
+            console.log('[GameModePanel] Clearing canvas from remote')
+            clearCanvas(false) // 다시 전송하지 않음
+            onCanvasCleared?.()
+        }
+    }, [shouldClearCanvas, onCanvasCleared])
+
+    // 수신된 그리기 데이터를 캔버스에 그리기
+    useEffect(() => {
+        if (!receivedDrawing || !canvasRef.current) return
+
+        const canvas = canvasRef.current
+        const ctx = canvas.getContext('2d')
+
+        try {
+            // content에서 스트로크 데이터 파싱
+            const content = receivedDrawing.content
+            const strokeData = typeof content === 'string' ? JSON.parse(content) : content
+
+            console.log('[GameModePanel] Drawing received stroke:', strokeData)
+
+            if (!Array.isArray(strokeData)) return
+
+            // 스트로크 그리기
+            strokeData.forEach((point, index) => {
+                if (point.type === 'start') {
+                    ctx.beginPath()
+                    ctx.moveTo(point.x, point.y)
+                    ctx.lineWidth = point.width || 3
+                    ctx.lineCap = 'round'
+                    ctx.strokeStyle = point.color || '#000000'
+                } else if (point.type === 'move') {
+                    ctx.lineTo(point.x, point.y)
+                    ctx.stroke()
+                    ctx.beginPath()
+                    ctx.moveTo(point.x, point.y)
+                } else if (point.type === 'end') {
+                    ctx.beginPath()
+                }
+            })
+
+            // 처리 완료 알림
+            onDrawingProcessed?.()
+        } catch (err) {
+            console.error('[GameModePanel] Error drawing received data:', err)
+        }
+    }, [receivedDrawing, onDrawingProcessed])
+
+    // 비눗방울 애니메이션 생성
+    const createBubble = useCallback((userId, content, isCorrect = false) => {
+        const id = `bubble-${Date.now()}-${Math.random()}`
+        const bubble = {
+            id,
+            userId,
+            content,
+            isCorrect,
+            x: Math.random() * (CANVAS_WIDTH - 100) + 50, // 랜덤 x 위치
+            startTime: Date.now(),
+        }
+        setBubbles(prev => [...prev, bubble])
+
+        // 3초 후 자동 삭제
+        setTimeout(() => {
+            setBubbles(prev => prev.filter(b => b.id !== id))
+        }, 3000)
+    }, [])
+
+    // correctAnswerBubble prop으로 정답 버블 생성 (정답일 때 특별 효과)
+    // + 정답 시 자동으로 다음 라운드로 이동 (출제자만)
+    useEffect(() => {
+        if (correctAnswerBubble) {
+            createBubble(correctAnswerBubble.userId, correctAnswerBubble.content, true) // isCorrect = true
+            onBubbleProcessed?.()
+
+            // 출제자인 경우 2초 후 자동으로 다음 라운드로 이동 (연결된 경우만)
+            if (isDrawer && isConnected && onSendMessage) {
+                console.log('[GameModePanel] Correct answer! Auto-skipping in 2 seconds...')
+                setTimeout(() => {
+                    // 다시 한번 연결 상태 확인
+                    if (isConnectedRef.current && onSendMessageRef.current) {
+                        console.log('[GameModePanel] Auto-skipping to next round...')
+                        onSendMessageRef.current('/skip', 'TEXT')
+                    }
+                }, 2000) // 2초 대기 후 스킵 (정답 효과 보여주기 위해)
+            }
+        }
+    }, [correctAnswerBubble, createBubble, onBubbleProcessed, isDrawer, isConnected, onSendMessage])
+
+    // 게임 중 모든 채팅 메시지를 비눗방울로 표시
+    const lastMessageIdRef = useRef(null)
+    useEffect(() => {
+        if (!isGameActive || !messages || messages.length === 0) return
+
+        // 마지막 메시지만 처리 (중복 방지)
+        const lastMessage = messages[messages.length - 1]
+        if (!lastMessage || lastMessage.id === lastMessageIdRef.current) return
+        if (lastMessage.isSystem || lastMessage.messageType === 'SYSTEM') return
+        if (lastMessage.messageType === 'DRAWING' || lastMessage.messageType === 'DRAWING_CLEAR') return
+
+        // 출제자의 메시지는 제외 (출제자가 답을 알려줘선 안 됨)
+        if (lastMessage.userId === gameState.currentDrawerId) return
+
+        lastMessageIdRef.current = lastMessage.id
+        createBubble(lastMessage.userId, lastMessage.content, false) // isCorrect = false
+    }, [messages, isGameActive, gameState.currentDrawerId, createBubble])
 
     // 점수 정렬
     const sortedScores = Object.entries(gameState.scores || {})
@@ -243,7 +437,10 @@ const GameModePanel = ({roomId, onGameMessage, initialGameStatus, onStartGame, o
                 <Button
                     variant="contained"
                     startIcon={<PlayIcon/>}
-                    onClick={handleStartGame}
+                    onClick={() => {
+                        console.log('[GameModePanel] Button clicked!')
+                        handleStartGame()
+                    }}
                     disabled={loading}
                     size="small"
                 >
@@ -324,6 +521,7 @@ const GameModePanel = ({roomId, onGameMessage, initialGameStatus, onStartGame, o
                     flexDirection: 'column',
                     p: 1,
                     bgcolor: isDark ? 'rgba(255,255,255,0.03)' : '#f5f5f5',
+                    position: 'relative',
                 }}
             >
                 <canvas
@@ -343,6 +541,83 @@ const GameModePanel = ({roomId, onGameMessage, initialGameStatus, onStartGame, o
                         height: CANVAS_HEIGHT,
                     }}
                 />
+
+                {/* 비눗방울 애니메이션 (모든 추측 + 정답) */}
+                {bubbles.map(bubble => {
+                    const elapsed = (Date.now() - bubble.startTime) / 1000
+                    const progress = Math.min(elapsed / 3, 1) // 3초 동안 애니메이션
+                    const y = CANVAS_HEIGHT * (1 - progress) // 아래에서 위로
+                    const opacity = 1 - progress * 0.8 // 점점 투명해짐
+                    const scale = 1 + progress * 0.3 // 약간 커짐
+
+                    return (
+                        <Box
+                            key={bubble.id}
+                            sx={{
+                                position: 'absolute',
+                                left: bubble.x,
+                                top: y,
+                                transform: `translate(-50%, -50%) scale(${scale})`,
+                                opacity,
+                                pointerEvents: 'none',
+                                transition: 'all 0.1s linear',
+                                animation: 'float 3s ease-out forwards',
+                                '@keyframes float': {
+                                    '0%': {
+                                        transform: 'translate(-50%, 0) scale(1)',
+                                        opacity: 1,
+                                    },
+                                    '100%': {
+                                        transform: 'translate(-50%, -200px) scale(1.3)',
+                                        opacity: 0,
+                                    },
+                                },
+                            }}
+                        >
+                            <Box
+                                sx={{
+                                    // 정답은 금색, 일반 추측은 파란색 비눗방울
+                                    background: bubble.isCorrect
+                                        ? 'linear-gradient(135deg, rgba(255,215,0,0.95) 0%, rgba(255,193,7,0.9) 50%, rgba(255,152,0,0.85) 100%)'
+                                        : 'linear-gradient(135deg, rgba(255,255,255,0.9) 0%, rgba(173,216,230,0.8) 50%, rgba(135,206,250,0.7) 100%)',
+                                    borderRadius: '50%',
+                                    padding: '8px 12px',
+                                    boxShadow: bubble.isCorrect
+                                        ? '0 4px 20px rgba(255,193,7,0.5), inset 0 -2px 10px rgba(255,255,255,0.6)'
+                                        : '0 4px 15px rgba(100,149,237,0.3), inset 0 -2px 10px rgba(255,255,255,0.5)',
+                                    border: bubble.isCorrect
+                                        ? '2px solid rgba(255,215,0,0.8)'
+                                        : '1px solid rgba(255,255,255,0.6)',
+                                    backdropFilter: 'blur(2px)',
+                                    minWidth: 60,
+                                    textAlign: 'center',
+                                }}
+                            >
+                                <Typography
+                                    variant="caption"
+                                    sx={{
+                                        display: 'block',
+                                        fontWeight: 700,
+                                        color: bubble.isCorrect ? '#b8860b' : '#1565c0',
+                                        fontSize: '0.65rem',
+                                    }}
+                                >
+                                    {bubble.isCorrect ? '🎉 ' : ''}{bubble.userId}
+                                </Typography>
+                                <Typography
+                                    variant="body2"
+                                    sx={{
+                                        fontWeight: 600,
+                                        color: bubble.isCorrect ? '#8b4513' : '#0d47a1',
+                                        fontSize: '0.8rem',
+                                    }}
+                                >
+                                    {bubble.content}
+                                </Typography>
+                            </Box>
+                        </Box>
+                    )
+                })}
 
                 {/* 그리기 도구 (출제자만) */}
                 {isDrawer && (
@@ -364,7 +639,7 @@ const GameModePanel = ({roomId, onGameMessage, initialGameStatus, onStartGame, o
                             />
                         ))}
                         <Tooltip title="지우기">
-                            <IconButton size="small" onClick={clearCanvas}>
+                            <IconButton size="small" onClick={() => clearCanvas(true)}>
                                 <ClearIcon fontSize="small"/>
                             </IconButton>
                         </Tooltip>

--- a/src/domains/freetalk/hooks/useChatWebSocket.js
+++ b/src/domains/freetalk/hooks/useChatWebSocket.js
@@ -15,6 +15,9 @@ export function useChatWebSocket(roomId, userId) {
     const [messages, setMessages] = useState([])
     const [gameState, setGameState] = useState(null)
     const [error, setError] = useState(null)
+    const [receivedDrawing, setReceivedDrawing] = useState(null)
+    const [shouldClearCanvas, setShouldClearCanvas] = useState(false)
+    const [correctAnswerBubble, setCorrectAnswerBubble] = useState(null)
 
     const isConnectedRef = useRef(false)
     const roomTokenRef = useRef(null)
@@ -60,31 +63,47 @@ export function useChatWebSocket(roomId, userId) {
                 },
 
                 onGameStart: (data) => {
+                    console.log('[useChatWebSocket] Game started - FULL DATA:', JSON.stringify(data, null, 2))
+                    // 실제 게임 데이터 추출 (data.data에 중첩되어 있을 수 있음)
+                    const gameData = data.data || data
+                    // currentWord는 객체: { korean, english, wordId }
+                    // 출제자만 currentWord를 받음
+                    const word = gameData.currentWord
                     setGameState({
                         status: 'PLAYING',
-                        currentRound: data.currentRound || 1,
-                        totalRounds: data.totalRounds || 5,
-                        currentDrawerId: data.currentDrawerId,
-                        currentWord: data.currentWord,
+                        currentRound: gameData.currentRound || 1,
+                        totalRounds: gameData.totalRounds || 5,
+                        currentDrawerId: gameData.currentDrawerId,
+                        currentWord: word?.korean || word, // 한글 제시어 사용
+                        currentWordEnglish: word?.english,
+                        drawerOrder: gameData.drawerOrder,
                         roundStartTime: Date.now(),
-                        scores: data.scores || {},
+                        scores: gameData.scores || {},
                     })
                 },
 
                 onGameEnd: (data) => {
+                    console.log('[useChatWebSocket] Game ended - FULL DATA:', JSON.stringify(data, null, 2))
+                    const gameData = data.data || data
                     setGameState((prev) => ({
                         ...prev,
                         status: 'FINISHED',
-                        finalScores: data.scores,
+                        finalScores: gameData.scores,
                     }))
                 },
 
                 onRoundStart: (data) => {
+                    console.log('[useChatWebSocket] Round started - FULL DATA:', JSON.stringify(data, null, 2))
+                    // 실제 라운드 데이터 추출 (data.data에 중첩되어 있을 수 있음)
+                    const roundData = data.data || data
+                    // currentWord는 객체: { korean, english, wordId }
+                    const word = roundData.currentWord
                     setGameState((prev) => ({
                         ...prev,
-                        currentRound: data.currentRound,
-                        currentDrawerId: data.currentDrawerId,
-                        currentWord: data.currentWord,
+                        currentRound: roundData.currentRound,
+                        currentDrawerId: roundData.currentDrawerId,
+                        currentWord: word?.korean || word,
+                        currentWordEnglish: word?.english,
                         roundStartTime: Date.now(),
                         hintUsed: false,
                         correctGuessers: [],
@@ -92,37 +111,90 @@ export function useChatWebSocket(roomId, userId) {
                 },
 
                 onRoundEnd: (data) => {
-                    setGameState((prev) => ({
-                        ...prev,
-                        scores: data.scores || prev?.scores,
-                    }))
+                    console.log('[useChatWebSocket] Round ended - FULL DATA:', JSON.stringify(data, null, 2))
+
+                    // 실제 라운드 데이터 추출 (data.data에 중첩되어 있을 수 있음)
+                    const roundData = data.data || data
+
+                    console.log('[useChatWebSocket] Extracted roundData:', roundData)
+
+                    // ROUND_END 처리 - 다음 라운드 정보 추출
+                    const nextRoundNum = roundData.nextRound ?? roundData.currentRound ?? ((data.currentRound || 0) + 1)
+                    const nextDrawer = roundData.nextDrawer ?? roundData.nextDrawerId ?? roundData.currentDrawerId
+                    const nextWord = roundData.nextWord ?? roundData.currentWord
+                    const scores = roundData.scores ?? data.scores
+
+                    setGameState((prev) => {
+                        if (!prev) return prev
+
+                        console.log('[useChatWebSocket] Updating gameState:', {
+                            prevRound: prev.currentRound,
+                            nextRoundNum,
+                            nextDrawer,
+                            nextWord,
+                            scores,
+                        })
+
+                        // 항상 다음 라운드로 전환 (ROUND_END는 라운드가 끝났다는 의미)
+                        return {
+                            ...prev,
+                            scores: scores || prev.scores,
+                            currentRound: nextRoundNum,
+                            currentDrawerId: nextDrawer,
+                            currentWord: nextWord?.korean || nextWord,
+                            currentWordEnglish: nextWord?.english,
+                            roundStartTime: Date.now(),
+                            hintUsed: false,
+                            correctGuessers: [],
+                        }
+                    })
                 },
 
                 onCorrectAnswer: (data) => {
+                    console.log('[useChatWebSocket] Correct answer - FULL DATA:', JSON.stringify(data, null, 2))
+                    const answerData = data.data || data
                     setGameState((prev) => ({
                         ...prev,
-                        correctGuessers: [...(prev?.correctGuessers || []), data.userId],
-                        scores: data.scores || prev?.scores,
+                        correctGuessers: [...(prev?.correctGuessers || []), answerData.userId],
+                        scores: answerData.scores || prev?.scores,
                     }))
+                    // 정답 비눗방울 표시 데이터 설정
+                    setCorrectAnswerBubble({
+                        userId: answerData.userId,
+                        content: answerData.content || '정답!',
+                        timestamp: Date.now(),
+                    })
                 },
 
                 onScoreUpdate: (data) => {
+                    const scoreData = data.data || data
                     setGameState((prev) => ({
                         ...prev,
-                        scores: data.scores,
+                        scores: scoreData.scores,
                     }))
                 },
 
                 onHint: (data) => {
+                    const hintData = data.data || data
                     setGameState((prev) => ({
                         ...prev,
-                        hint: data.hint,
+                        hint: hintData.hint,
                         hintUsed: true,
                     }))
                 },
 
                 onDrawing: (data) => {
-                    // 캔버스에 그리기 데이터 적용 (별도 핸들러로 처리)
+                    // 캔버스에 그리기 데이터 적용
+                    console.log('[useChatWebSocket] Drawing received:', data)
+                    // data.data가 있으면 그것을 사용, 없으면 원본 data 사용
+                    const drawingData = data.data || data
+                    setReceivedDrawing(drawingData)
+                },
+
+                onDrawingClear: () => {
+                    // 캔버스 초기화
+                    console.log('[useChatWebSocket] Drawing clear received')
+                    setShouldClearCanvas(true)
                 },
 
                 onUserJoin: (data) => {
@@ -163,7 +235,13 @@ export function useChatWebSocket(roomId, userId) {
             isConnectedRef.current = true
         } catch (err) {
             console.error('[useChatWebSocket] Connection error:', err)
-            setError('연결에 실패했습니다')
+            console.error('[useChatWebSocket] Error details:', {
+                message: err.message,
+                stack: err.stack,
+                roomId,
+                userId
+            })
+            setError('연결에 실패했습니다: ' + err.message)
             setIsConnected(false)
             isConnectedRef.current = false
         }
@@ -184,7 +262,8 @@ export function useChatWebSocket(roomId, userId) {
      */
     const sendMessage = useCallback((content, messageType = 'TEXT') => {
         if (!isConnectedRef.current) {
-            setError('연결되지 않았습니다')
+            console.warn('[useChatWebSocket] Not connected, cannot send message:', content)
+            // 연결 안 됐을 때는 에러 설정하지 않고 조용히 실패
             return false
         }
 
@@ -209,7 +288,24 @@ export function useChatWebSocket(roomId, userId) {
      * 그리기 데이터 전송
      */
     const sendDrawing = useCallback((drawingData) => {
+        console.log('[useChatWebSocket] sendDrawing, isConnected:', isConnectedRef.current)
+        if (!isConnectedRef.current) {
+            console.error('[useChatWebSocket] Not connected, cannot send drawing')
+            return
+        }
         chatWebSocketService.sendDrawing(drawingData)
+    }, [])
+
+    /**
+     * 캔버스 초기화 전송
+     */
+    const clearDrawing = useCallback(() => {
+        console.log('[useChatWebSocket] clearDrawing, isConnected:', isConnectedRef.current)
+        if (!isConnectedRef.current) {
+            console.error('[useChatWebSocket] Not connected, cannot clear drawing')
+            return
+        }
+        chatWebSocketService.clearDrawing()
     }, [])
 
     /**
@@ -243,6 +339,9 @@ export function useChatWebSocket(roomId, userId) {
         messages,
         gameState,
         error,
+        receivedDrawing,
+        shouldClearCanvas,
+        correctAnswerBubble,
 
         // 액션
         connect,
@@ -251,11 +350,15 @@ export function useChatWebSocket(roomId, userId) {
         startGame,
         stopGame,
         sendDrawing,
+        clearDrawing,
         clearError,
         clearMessages,
 
         // 유틸
         setMessages,
+        setReceivedDrawing,
+        setShouldClearCanvas,
+        setCorrectAnswerBubble,
     }
 }
 

--- a/src/domains/freetalk/pages/ChatRoomPage.jsx
+++ b/src/domains/freetalk/pages/ChatRoomPage.jsx
@@ -24,6 +24,7 @@ import {
 import {chatRoomService, messageService, voiceService} from '../../chat/services/chatService'
 import {useAuth} from '../../../contexts/AuthContext'
 import {useChatWebSocket} from '../hooks/useChatWebSocket'
+import GameModePanel from '../components/GameModePanel'
 
 const levelColors = {
     beginner: {bg: '#e8f5e9', color: '#2e7d32', label: '초급'},
@@ -55,11 +56,21 @@ const ChatRoomPage = () => {
         messages,
         gameState,
         error: wsError,
+        receivedDrawing,
+        shouldClearCanvas,
+        correctAnswerBubble,
         connect: wsConnect,
         disconnect: wsDisconnect,
         sendMessage: wsSendMessage,
+        startGame: wsStartGame,
+        stopGame: wsStopGame,
+        sendDrawing: wsSendDrawing,
+        clearDrawing: wsClearDrawing,
         clearError: wsClearError,
         setMessages,
+        setReceivedDrawing,
+        setShouldClearCanvas,
+        setCorrectAnswerBubble,
     } = useChatWebSocket(roomId, currentUserId)
 
     // 채팅방 정보 조회
@@ -115,9 +126,12 @@ const ChatRoomPage = () => {
 
     // WebSocket 연결 (별도 effect)
     useEffect(() => {
+        console.log('[ChatRoomPage] WebSocket effect triggered:', {roomId, currentUserId, isConnected})
         if (currentUserId && roomId) {
             console.log('[ChatRoomPage] Connecting WebSocket...', {roomId, currentUserId})
             wsConnect()
+        } else {
+            console.log('[ChatRoomPage] Missing required values:', {roomId, currentUserId})
         }
 
         return () => {
@@ -299,13 +313,44 @@ const ChatRoomPage = () => {
                 </Alert>
             )}
 
-            {/* 게임 상태 표시 */}
-            {gameState?.status === 'PLAYING' && (
-                <Alert severity="info" sx={{m: 1}}>
-                    🎮 게임 진행 중! 라운드 {gameState.currentRound}/{gameState.totalRounds}
-                    {gameState.currentDrawerId === currentUserId && ` - 제시어: ${gameState.currentWord}`}
-                </Alert>
-            )}
+            {/* 게임 모드 패널 - 항상 표시 (게임 상태에 따라 다른 UI) */}
+            <Box sx={{
+                borderBottom: 1,
+                borderColor: 'divider',
+                ...(gameState?.status === 'PLAYING' ? {
+                    maxHeight: '50vh',
+                    overflow: 'auto',
+                } : {}),
+            }}>
+                <GameModePanel
+                    roomId={roomId}
+                    initialGameStatus={gameState?.status}
+                    wsGameState={gameState}
+                    isConnected={isConnected}
+                    messages={messages}
+                    onStartGame={wsStartGame}
+                    onStopGame={wsStopGame}
+                    onSendMessage={wsSendMessage}
+                    onSendDrawing={wsSendDrawing}
+                    onClearDrawing={wsClearDrawing}
+                    receivedDrawing={receivedDrawing}
+                    onDrawingProcessed={() => setReceivedDrawing(null)}
+                    shouldClearCanvas={shouldClearCanvas}
+                    onCanvasCleared={() => setShouldClearCanvas(false)}
+                    correctAnswerBubble={correctAnswerBubble}
+                    onBubbleProcessed={() => setCorrectAnswerBubble(null)}
+                    onGameMessage={(msg) => {
+                        const systemMessage = {
+                            id: `game-${Date.now()}`,
+                            content: msg.content,
+                            messageType: 'SYSTEM',
+                            createdAt: new Date().toISOString(),
+                            isSystem: true,
+                        }
+                        setMessages((prev) => [...prev, systemMessage])
+                    }}
+                />
+            </Box>
 
             {/* 메시지 영역 */}
             <Box

--- a/src/domains/freetalk/services/chatWebSocketService.js
+++ b/src/domains/freetalk/services/chatWebSocketService.js
@@ -49,10 +49,8 @@ class ChatWebSocketConnection {
                     this.reconnectAttempts = 0
                     console.log('[ChatWebSocket] Connected')
 
-                    // 연결 후 방 입장 메시지 전송
-                    if (roomId) {
-                        this.joinRoom(roomId)
-                    }
+                    // 연결 후 방 입장은 roomToken으로 이미 처리됨
+                    // joinRoom action은 서버에서 지원하지 않음 (Forbidden)
 
                     resolve()
                 }
@@ -107,49 +105,75 @@ class ChatWebSocketConnection {
      */
     handleMessage(data) {
         const {type, messageType} = data
+        console.log('[ChatWebSocket] Received message:', {type, messageType, data})
 
-        // 메시지 타입에 따라 콜백 호출
+        // 메시지 타입에 따라 콜백 호출 (대소문자 모두 처리)
         switch (type || messageType) {
             case 'message':
             case 'TEXT':
                 this.callbacks.onMessage?.(data)
                 break
             case 'game_start':
+            case 'GAME_START':
                 this.callbacks.onGameStart?.(data)
                 break
             case 'game_end':
+            case 'GAME_END':
                 this.callbacks.onGameEnd?.(data)
                 break
             case 'round_start':
+            case 'ROUND_START':
+                console.log('[ChatWebSocket] Round start received:', data)
                 this.callbacks.onRoundStart?.(data)
                 break
             case 'round_end':
+            case 'ROUND_END':
+                console.log('[ChatWebSocket] Round end received:', data)
                 this.callbacks.onRoundEnd?.(data)
                 break
             case 'drawing':
+            case 'DRAWING':
+                console.log('[ChatWebSocket] Drawing data received:', data)
                 this.callbacks.onDrawing?.(data)
                 break
+            case 'drawing_clear':
+            case 'DRAWING_CLEAR':
+                console.log('[ChatWebSocket] Drawing clear received')
+                this.callbacks.onDrawingClear?.()
+                break
             case 'correct_answer':
+            case 'CORRECT_ANSWER':
+                console.log('[ChatWebSocket] Correct answer received:', data)
                 this.callbacks.onCorrectAnswer?.(data)
                 break
             case 'score_update':
+            case 'SCORE_UPDATE':
                 this.callbacks.onScoreUpdate?.(data)
                 break
             case 'hint':
+            case 'HINT':
                 this.callbacks.onHint?.(data)
                 break
             case 'user_join':
+            case 'USER_JOIN':
                 this.callbacks.onUserJoin?.(data)
                 break
             case 'user_leave':
+            case 'USER_LEAVE':
                 this.callbacks.onUserLeave?.(data)
                 break
             case 'system_command':
+            case 'SYSTEM_COMMAND':
                 // 시스템 명령어 응답 (예: /member, /help 등)
                 this.callbacks.onMessage?.(data)
                 break
             case 'error':
+            case 'ERROR':
                 this.callbacks.onError?.(data)
+                break
+            case 'GUESS':
+                // 추측 메시지 - 일반 메시지로 처리
+                this.callbacks.onMessage?.(data)
                 break
             default:
                 console.log('[ChatWebSocket] Unknown message type:', type || messageType, data)
@@ -188,6 +212,7 @@ class ChatWebSocketConnection {
             return false
         }
 
+        console.log('[ChatWebSocket] Sending message with userId:', this.userId, 'content:', content)
         this.send({
             action: 'sendMessage',
             roomId: this.roomId,
@@ -213,14 +238,34 @@ class ChatWebSocketConnection {
     }
 
     /**
-     * 그리기 데이터 전송
+     * 그리기 데이터 전송 - sendMessage action 사용
      */
     sendDrawing(drawingData) {
+        console.log('[ChatWebSocket] sendDrawing called:', drawingData)
+        // 서버가 sendMessage action만 지원하므로 messageType으로 구분
+        // content는 반드시 문자열이어야 함
+        const content = typeof drawingData === 'string' ? drawingData : JSON.stringify(drawingData)
+        console.log('[ChatWebSocket] sendDrawing content:', content)
         this.send({
-            action: 'sendDrawing',
+            action: 'sendMessage',
             roomId: this.roomId,
             userId: this.userId,
-            drawingData,
+            content: content,
+            messageType: 'DRAWING',
+        })
+    }
+
+    /**
+     * 캔버스 초기화 전송
+     */
+    clearDrawing() {
+        console.log('[ChatWebSocket] clearDrawing called')
+        this.send({
+            action: 'sendMessage',
+            roomId: this.roomId,
+            userId: this.userId,
+            content: '',
+            messageType: 'DRAWING_CLEAR',
         })
     }
 
@@ -336,6 +381,14 @@ export const chatWebSocketService = {
     sendDrawing(drawingData) {
         const instance = this.getInstance()
         return instance.sendDrawing(drawingData)
+    },
+
+    /**
+     * 캔버스 초기화 전송
+     */
+    clearDrawing() {
+        const instance = this.getInstance()
+        return instance.clearDrawing()
     },
 
     /**


### PR DESCRIPTION
## Summary
- 캐치마인드 게임에서 라운드 전환이 안 되는 문제 수정
- WebSocket 메시지 중첩 데이터 구조 파싱 개선
- 타이머 자동 스킵 및 비눗방울 애니메이션 추가

## Changes
- WebSocket 이벤트 핸들러에서 `data.data || data` 패턴으로 중첩 데이터 처리
- 메시지 타입 대소문자 모두 처리 (round_end/ROUND_END 등)
- 타이머 자동 스킵 시 stale closure 문제 해결 (useRef 사용)
- 연결 안 된 상태에서 에러 대신 조용히 실패 처리
- 게임 중 채팅 메시지 비눗방울 애니메이션 추가

## Test plan
- [ ] 게임 시작 후 타이머 0초 → 자동 스킵 확인
- [ ] 정답 맞추면 다음 라운드로 전환 확인
- [ ] /skip 명령어로 수동 스킵 확인
- [ ] 채팅 메시지 비눗방울 애니메이션 확인

Closes #165