### PR TITLE
[FIX] Add fallback to VITE_API_URL for chat and vocab APIs

### DIFF
--- a/.github/workflows/github-jira-issue-sync.yml
+++ b/.github/workflows/github-jira-issue-sync.yml
@@ -289,11 +289,12 @@ jobs:
           JIRA_BASE_URL: ${{ secrets.JIRA_BASE_URL }}
           JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
           JIRA_USER_EMAIL: ${{ secrets.JIRA_USER_EMAIL }}
+          DESC_JSON: ${{ steps.parse.outputs.description }}
         with:
           script: |
             const jiraKey = '${{ steps.get-jira-key.outputs.jira_key }}';
             const issue = context.payload.issue;
-            const descContent = ${{ steps.parse.outputs.description }};
+            const descContent = JSON.parse(process.env.DESC_JSON);
             
             const response = await fetch(
               `${process.env.JIRA_BASE_URL}/rest/api/3/issue/${jiraKey}`,

--- a/.github/workflows/github-jira-pr-sync.yml
+++ b/.github/workflows/github-jira-pr-sync.yml
@@ -204,11 +204,13 @@ jobs:
           JIRA_BASE_URL: ${{ secrets.JIRA_BASE_URL }}
           JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
           JIRA_USER_EMAIL: ${{ secrets.JIRA_USER_EMAIL }}
+          DESC_JSON: ${{ steps.parse.outputs.description }}
+          
         with:
           script: |
             const jiraKey = '${{ steps.get-jira-key.outputs.jira_key }}';
             const pr = context.payload.pull_request;
-            const descContent = ${{ steps.parse.outputs.description }};
+            const descContent = JSON.parse(process.env.DESC_JSON);
             
             const response = await fetch(
               `${process.env.JIRA_BASE_URL}/rest/api/3/issue/${jiraKey}`,

--- a/src/api/chatApi.js
+++ b/src/api/chatApi.js
@@ -1,7 +1,7 @@
 import axios from 'axios'
 
 const chatApi = axios.create({
-    baseURL: import.meta.env.VITE_CHAT_API_URL,
+    baseURL: import.meta.env.VITE_CHAT_API_URL || import.meta.env.VITE_API_URL,
     timeout: 10000,
     headers: {
         'Content-Type': 'application/json',

--- a/src/api/vocabApi.js
+++ b/src/api/vocabApi.js
@@ -1,7 +1,7 @@
 import axios from 'axios'
 
 const vocabApi = axios.create({
-    baseURL: import.meta.env.VITE_VOCAB_API_URL,
+    baseURL: import.meta.env.VITE_VOCAB_API_URL || import.meta.env.VITE_API_URL,
     timeout: 10000,
     headers: {
         'Content-Type': 'application/json',


### PR DESCRIPTION
## Summary
- chatApi.js와 vocabApi.js에 VITE_API_URL fallback 추가
- 개별 API URL이 설정되지 않은 경우 기본 API URL 사용

## Test plan
- [ ] 프로덕션 배포 후 채팅 API 정상 동작 확인
- [ ] 프로덕션 배포 후 단어장 API 정상 동작 확인