### PR TITLE
[FEAT] 채팅 슬래시 명령어 시스템 구현 (#200)

### DIFF
--- a/src/domains/freetalk/components/CommandAutocomplete.jsx
+++ b/src/domains/freetalk/components/CommandAutocomplete.jsx
@@ -1,0 +1,150 @@
+import { useEffect, useState } from 'react'
+import { Box, Paper, Typography, List, ListItem, ListItemButton, ListItemText } from '@mui/material'
+import { useThemeMode } from '../../../contexts/ThemeContext'
+import { searchCommands } from '../types/chatCommandTypes'
+
+/**
+ * 채팅 명령어 자동완성 컴포넌트
+ * 사용자가 "/"를 입력하면 사용 가능한 명령어 목록을 표시합니다.
+ *
+ * @param {Object} props
+ * @param {string} props.input - 현재 입력 값
+ * @param {function} props.onSelect - 명령어 선택 시 호출되는 콜백
+ * @param {boolean} props.show - 표시 여부
+ * @returns {JSX.Element|null}
+ */
+const CommandAutocomplete = ({ input, onSelect, show }) => {
+  const { mode } = useThemeMode()
+  const isDark = mode === 'dark'
+  const [selectedIndex, setSelectedIndex] = useState(0)
+  const [filteredCommands, setFilteredCommands] = useState([])
+
+  // 입력값에 따라 명령어 필터링
+  useEffect(() => {
+    if (!show || !input.startsWith('/')) {
+      setFilteredCommands([])
+      setSelectedIndex(0)
+      return
+    }
+
+    const commands = searchCommands(input)
+    setFilteredCommands(commands)
+    setSelectedIndex(0)
+  }, [input, show])
+
+  // 키보드 이벤트 처리
+  useEffect(() => {
+    const handleKeyDown = (e) => {
+      if (!show || filteredCommands.length === 0) return
+
+      if (e.key === 'ArrowDown') {
+        e.preventDefault()
+        setSelectedIndex((prev) => (prev + 1) % filteredCommands.length)
+      } else if (e.key === 'ArrowUp') {
+        e.preventDefault()
+        setSelectedIndex((prev) => (prev - 1 + filteredCommands.length) % filteredCommands.length)
+      } else if (e.key === 'Enter' && filteredCommands[selectedIndex]) {
+        e.preventDefault()
+        onSelect(filteredCommands[selectedIndex].command)
+      } else if (e.key === 'Escape') {
+        onSelect('')
+      }
+    }
+
+    window.addEventListener('keydown', handleKeyDown)
+    return () => window.removeEventListener('keydown', handleKeyDown)
+  }, [show, filteredCommands, selectedIndex, onSelect])
+
+  // 표시할 항목이 없으면 렌더링하지 않음
+  if (!show || filteredCommands.length === 0) {
+    return null
+  }
+
+  return (
+    <Paper
+      elevation={8}
+      sx={{
+        position: 'absolute',
+        bottom: '100%',
+        left: 0,
+        right: 0,
+        mb: 1,
+        maxHeight: 300,
+        overflow: 'auto',
+        bgcolor: isDark ? '#1e293b' : '#ffffff',
+        border: isDark ? '1px solid rgba(255,255,255,0.1)' : '1px solid #e0e0e0',
+        borderRadius: 2,
+        zIndex: 1000,
+      }}
+    >
+      <Box sx={{ p: 1.5, borderBottom: isDark ? '1px solid rgba(255,255,255,0.1)' : '1px solid #e0e0e0' }}>
+        <Typography variant="caption" color="text.secondary" fontWeight={600}>
+          사용 가능한 명령어 ({filteredCommands.length})
+        </Typography>
+      </Box>
+
+      <List sx={{ p: 0 }}>
+        {filteredCommands.map((cmd, index) => (
+          <ListItem key={cmd.command} disablePadding>
+            <ListItemButton
+              selected={index === selectedIndex}
+              onClick={() => onSelect(cmd.command)}
+              sx={{
+                py: 1.5,
+                px: 2,
+                '&.Mui-selected': {
+                  bgcolor: isDark ? 'rgba(250, 204, 21, 0.2)' : 'rgba(254, 229, 0, 0.3)',
+                  '&:hover': {
+                    bgcolor: isDark ? 'rgba(250, 204, 21, 0.25)' : 'rgba(254, 229, 0, 0.4)',
+                  },
+                },
+                '&:hover': {
+                  bgcolor: isDark ? 'rgba(255,255,255,0.05)' : 'rgba(0,0,0,0.04)',
+                },
+              }}
+            >
+              <ListItemText
+                primary={
+                  <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                    <Typography
+                      variant="body2"
+                      fontWeight={600}
+                      sx={{
+                        fontFamily: 'monospace',
+                        color: isDark ? '#facc15' : '#f59e0b',
+                      }}
+                    >
+                      {cmd.command}
+                    </Typography>
+                    <Typography variant="caption" color="text.secondary">
+                      {cmd.usage}
+                    </Typography>
+                  </Box>
+                }
+                secondary={
+                  <Typography variant="caption" color="text.secondary" sx={{ mt: 0.5 }}>
+                    {cmd.description}
+                  </Typography>
+                }
+              />
+            </ListItemButton>
+          </ListItem>
+        ))}
+      </List>
+
+      <Box
+        sx={{
+          p: 1,
+          bgcolor: isDark ? 'rgba(255,255,255,0.03)' : '#f5f5f5',
+          borderTop: isDark ? '1px solid rgba(255,255,255,0.1)' : '1px solid #e0e0e0',
+        }}
+      >
+        <Typography variant="caption" color="text.secondary">
+          화살표로 선택, Enter로 입력, Esc로 닫기
+        </Typography>
+      </Box>
+    </Paper>
+  )
+}
+
+export default CommandAutocomplete

--- a/src/domains/freetalk/components/PollCard.jsx
+++ b/src/domains/freetalk/components/PollCard.jsx
@@ -1,0 +1,175 @@
+import { useState } from 'react'
+import { Box, Button, Card, CardContent, Chip, Typography, IconButton } from '@mui/material'
+import {
+  HowToVote as VoteIcon,
+  CheckCircle as CheckIcon,
+  Cancel as CancelIcon,
+  Person as PersonIcon,
+} from '@mui/icons-material'
+import { useThemeMode } from '../../../contexts/ThemeContext'
+import { calculatePollResults } from '../types/chatCommandTypes'
+import PollResultBar from './PollResultBar'
+
+/**
+ * 투표 카드 컴포넌트
+ * 투표 생성, 투표하기, 결과 보기 기능을 제공합니다.
+ *
+ * @param {Object} props
+ * @param {Object} props.poll - 투표 데이터
+ * @param {string} props.currentUserId - 현재 사용자 ID
+ * @param {function} props.onVote - 투표 시 호출되는 콜백
+ * @param {function} props.onEndPoll - 투표 종료 시 호출되는 콜백
+ * @returns {JSX.Element}
+ */
+const PollCard = ({ poll, currentUserId, onVote, onEndPoll }) => {
+  const { mode } = useThemeMode()
+  const isDark = mode === 'dark'
+  const [selectedOption, setSelectedOption] = useState(null)
+
+  const { totalVotes, percentages } = calculatePollResults(poll.options)
+  const hasVoted = poll.options.some((opt) => opt.voters.includes(currentUserId))
+  const isCreator = poll.creatorId === currentUserId
+  const showResults = !poll.isActive || hasVoted
+
+  const handleVote = (optionId) => {
+    if (!poll.isActive || hasVoted) return
+    setSelectedOption(optionId)
+    onVote?.(poll.pollId, optionId)
+  }
+
+  const handleEndPoll = () => {
+    onEndPoll?.(poll.pollId)
+  }
+
+  return (
+    <Card
+      elevation={2}
+      sx={{
+        maxWidth: 500,
+        bgcolor: isDark ? '#1e293b' : '#ffffff',
+        border: isDark ? '1px solid rgba(255,255,255,0.1)' : '1px solid #e0e0e0',
+        borderRadius: 2,
+      }}
+    >
+      <CardContent sx={{ p: 2 }}>
+        {/* 헤더 */}
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 2 }}>
+          <VoteIcon sx={{ color: isDark ? '#facc15' : '#f59e0b' }} />
+          <Typography variant="subtitle2" fontWeight={600}>
+            투표
+          </Typography>
+          {poll.isActive ? (
+            <Chip
+              label="진행 중"
+              size="small"
+              color="success"
+              sx={{ ml: 'auto', height: 20, fontSize: '0.7rem' }}
+            />
+          ) : (
+            <Chip
+              label="종료됨"
+              size="small"
+              color="default"
+              sx={{ ml: 'auto', height: 20, fontSize: '0.7rem' }}
+            />
+          )}
+        </Box>
+
+        {/* 질문 */}
+        <Typography variant="body1" fontWeight={600} sx={{ mb: 2 }}>
+          {poll.question}
+        </Typography>
+
+        {/* 옵션 목록 */}
+        <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.5, mb: 2 }}>
+          {poll.options.map((option, index) => {
+            const percentage = percentages[index]
+            const isSelected = selectedOption === option.optionId
+            const userVoted = option.voters.includes(currentUserId)
+
+            return (
+              <Box key={option.optionId}>
+                {showResults ? (
+                  // 결과 보기 모드
+                  <Box>
+                    <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', mb: 0.5 }}>
+                      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                        <Typography variant="body2" fontWeight={userVoted ? 600 : 400}>
+                          {option.text}
+                        </Typography>
+                        {userVoted && <CheckIcon sx={{ fontSize: 16, color: 'success.main' }} />}
+                      </Box>
+                      <Typography variant="caption" color="text.secondary">
+                        {option.voteCount}표 ({percentage}%)
+                      </Typography>
+                    </Box>
+                    <PollResultBar percentage={percentage} isUserVoted={userVoted} />
+                  </Box>
+                ) : (
+                  // 투표하기 모드
+                  <Button
+                    fullWidth
+                    variant={isSelected ? 'contained' : 'outlined'}
+                    onClick={() => handleVote(option.optionId)}
+                    disabled={!poll.isActive}
+                    sx={{
+                      justifyContent: 'flex-start',
+                      textTransform: 'none',
+                      py: 1.5,
+                      borderRadius: 2,
+                      bgcolor: isSelected ? (isDark ? '#facc15' : '#fee500') : 'transparent',
+                      color: isSelected ? '#1c1917' : 'inherit',
+                      borderColor: isDark ? 'rgba(255,255,255,0.2)' : '#e0e0e0',
+                      '&:hover': {
+                        bgcolor: isSelected
+                          ? isDark
+                            ? '#fbbf24'
+                            : '#fde047'
+                          : isDark
+                            ? 'rgba(255,255,255,0.05)'
+                            : 'rgba(0,0,0,0.04)',
+                      },
+                    }}
+                  >
+                    <Typography variant="body2">{option.text}</Typography>
+                  </Button>
+                )}
+              </Box>
+            )
+          })}
+        </Box>
+
+        {/* 하단 정보 */}
+        <Box
+          sx={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+            pt: 1.5,
+            borderTop: isDark ? '1px solid rgba(255,255,255,0.1)' : '1px solid #e0e0e0',
+          }}
+        >
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+            <PersonIcon sx={{ fontSize: 16, color: 'text.secondary' }} />
+            <Typography variant="caption" color="text.secondary">
+              총 {totalVotes}명 참여
+            </Typography>
+          </Box>
+
+          {isCreator && poll.isActive && (
+            <IconButton size="small" onClick={handleEndPoll} color="error" title="투표 종료">
+              <CancelIcon fontSize="small" />
+            </IconButton>
+          )}
+        </Box>
+
+        {/* 생성자 정보 */}
+        <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mt: 1 }}>
+          생성자: {poll.creatorId}
+        </Typography>
+      </CardContent>
+    </Card>
+  )
+}
+
+export default PollCard

--- a/src/domains/freetalk/components/PollResultBar.jsx
+++ b/src/domains/freetalk/components/PollResultBar.jsx
@@ -1,0 +1,57 @@
+import { Box, LinearProgress } from '@mui/material'
+import { useThemeMode } from '../../../contexts/ThemeContext'
+
+/**
+ * 투표 결과 진행바 컴포넌트
+ * 투표 옵션의 득표율을 시각적으로 표시합니다.
+ *
+ * @param {Object} props
+ * @param {number} props.percentage - 득표율 (0-100)
+ * @param {boolean} props.isUserVoted - 사용자가 해당 옵션에 투표했는지 여부
+ * @returns {JSX.Element}
+ */
+const PollResultBar = ({ percentage, isUserVoted = false }) => {
+  const { mode } = useThemeMode()
+  const isDark = mode === 'dark'
+
+  return (
+    <Box sx={{ position: 'relative', width: '100%' }}>
+      <LinearProgress
+        variant="determinate"
+        value={percentage}
+        sx={{
+          height: 8,
+          borderRadius: 1,
+          bgcolor: isDark ? 'rgba(255,255,255,0.1)' : 'rgba(0,0,0,0.1)',
+          '& .MuiLinearProgress-bar': {
+            borderRadius: 1,
+            bgcolor: isUserVoted
+              ? isDark
+                ? '#facc15'
+                : '#fee500'
+              : isDark
+                ? 'rgba(250, 204, 21, 0.5)'
+                : 'rgba(254, 229, 0, 0.5)',
+            transition: 'transform 0.4s ease-in-out',
+          },
+        }}
+      />
+      {isUserVoted && (
+        <Box
+          sx={{
+            position: 'absolute',
+            top: 0,
+            left: 0,
+            right: 0,
+            bottom: 0,
+            borderRadius: 1,
+            border: `2px solid ${isDark ? '#fbbf24' : '#fde047'}`,
+            pointerEvents: 'none',
+          }}
+        />
+      )}
+    </Box>
+  )
+}
+
+export default PollResultBar

--- a/src/domains/freetalk/components/SystemCommandMessage.jsx
+++ b/src/domains/freetalk/components/SystemCommandMessage.jsx
@@ -1,0 +1,196 @@
+import { Box, Paper, Typography } from '@mui/material'
+import { useThemeMode } from '../../../contexts/ThemeContext'
+import { SystemCommandConfig } from '../types/chatCommandTypes'
+
+/**
+ * 시스템 명령어 메시지 컴포넌트
+ * /dice, /coin, /random, /members, /help 등의 명령어 결과를 표시합니다.
+ *
+ * @param {Object} props
+ * @param {Object} props.data - 시스템 명령어 데이터
+ * @param {string} props.data.commandType - 명령어 타입
+ * @param {string} props.data.userId - 실행한 사용자 ID
+ * @param {Object} props.data.result - 명령어 결과
+ * @param {string} props.data.displayText - 표시할 텍스트
+ * @returns {JSX.Element}
+ */
+const SystemCommandMessage = ({ data }) => {
+  const { mode } = useThemeMode()
+  const isDark = mode === 'dark'
+
+  const config = SystemCommandConfig[data.commandType] || SystemCommandConfig.help
+  const { icon, color, bgColor } = config
+
+  return (
+    <Box sx={{ width: '100%', display: 'flex', justifyContent: 'center', py: 1 }}>
+      <Paper
+        elevation={0}
+        sx={{
+          px: 3,
+          py: 1.5,
+          bgcolor: isDark ? 'rgba(255,255,255,0.05)' : bgColor,
+          border: isDark ? `1px solid ${color}40` : `1px solid ${color}20`,
+          borderRadius: 3,
+          maxWidth: '80%',
+        }}
+      >
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5 }}>
+          {/* 아이콘 */}
+          <Box
+            sx={{
+              fontSize: '1.5rem',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+            }}
+          >
+            {icon}
+          </Box>
+
+          {/* 내용 */}
+          <Box sx={{ flex: 1 }}>
+            <Box sx={{ display: 'flex', alignItems: 'baseline', gap: 1 }}>
+              <Typography
+                variant="caption"
+                sx={{
+                  fontWeight: 600,
+                  color: isDark ? '#9ca3af' : 'text.secondary',
+                }}
+              >
+                {data.userId}
+              </Typography>
+              <Typography
+                variant="body2"
+                sx={{
+                  fontWeight: 500,
+                  color: isDark ? '#fafaf9' : color,
+                }}
+              >
+                {data.displayText}
+              </Typography>
+            </Box>
+
+            {/* 추가 결과 정보 */}
+            {renderCommandResult(data.commandType, data.result, isDark)}
+          </Box>
+        </Box>
+      </Paper>
+    </Box>
+  )
+}
+
+/**
+ * 명령어 타입별 결과 렌더링
+ */
+function renderCommandResult(commandType, result, isDark) {
+  if (!result) return null
+
+  switch (commandType) {
+    case 'dice':
+      return (
+        <Typography
+          variant="h5"
+          sx={{
+            mt: 0.5,
+            fontWeight: 700,
+            color: isDark ? '#facc15' : '#f59e0b',
+            fontFamily: 'monospace',
+          }}
+        >
+          {result.value}
+        </Typography>
+      )
+
+    case 'coin':
+      return (
+        <Typography
+          variant="body1"
+          sx={{
+            mt: 0.5,
+            fontWeight: 600,
+            color: isDark ? '#facc15' : '#f59e0b',
+          }}
+        >
+          {result.side === 'heads' ? '앞면' : '뒷면'}
+        </Typography>
+      )
+
+    case 'random':
+      return (
+        <Typography
+          variant="h6"
+          sx={{
+            mt: 0.5,
+            fontWeight: 700,
+            color: isDark ? '#06b6d4' : '#0891b2',
+            fontFamily: 'monospace',
+          }}
+        >
+          {result.value}
+          {result.min !== undefined && result.max !== undefined && (
+            <Typography
+              component="span"
+              variant="caption"
+              sx={{ ml: 1, color: 'text.secondary' }}
+            >
+              ({result.min}-{result.max})
+            </Typography>
+          )}
+        </Typography>
+      )
+
+    case 'members':
+      return result.memberIds ? (
+        <Box sx={{ mt: 1 }}>
+          <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mb: 0.5 }}>
+            참여 중인 멤버 ({result.totalCount}명):
+          </Typography>
+          <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5 }}>
+            {result.memberIds.map((memberId) => (
+              <Typography
+                key={memberId}
+                variant="caption"
+                sx={{
+                  px: 1,
+                  py: 0.25,
+                  bgcolor: isDark ? 'rgba(255,255,255,0.1)' : 'rgba(0,0,0,0.05)',
+                  borderRadius: 1,
+                  fontWeight: 500,
+                }}
+              >
+                {memberId}
+              </Typography>
+            ))}
+          </Box>
+        </Box>
+      ) : null
+
+    case 'help':
+      return result.commands ? (
+        <Box sx={{ mt: 1 }}>
+          <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mb: 0.5 }}>
+            사용 가능한 명령어:
+          </Typography>
+          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.5 }}>
+            {result.commands.map((cmd) => (
+              <Typography
+                key={cmd.command}
+                variant="caption"
+                sx={{
+                  fontFamily: 'monospace',
+                  color: isDark ? '#facc15' : '#f59e0b',
+                }}
+              >
+                {cmd.command} - {cmd.description}
+              </Typography>
+            ))}
+          </Box>
+        </Box>
+      ) : null
+
+    default:
+      return null
+  }
+}
+
+export default SystemCommandMessage

--- a/src/domains/freetalk/hooks/useChatWebSocket.js
+++ b/src/domains/freetalk/hooks/useChatWebSocket.js
@@ -77,6 +77,8 @@ export function useChatWebSocket(roomId, userId) {
                         messageType: data.messageType || 'TEXT',
                         createdAt: data.createdAt || new Date().toISOString(),
                         isOwn: data.userId === userId,
+                        // 추가 데이터 (투표, 시스템 명령어 등)
+                        data: data.data || data.payload,
                     }
                     setMessages((prev) => {
                         // 중복 메시지 방지 (같은 messageId가 이미 있으면 추가하지 않음)
@@ -85,6 +87,94 @@ export function useChatWebSocket(roomId, userId) {
                         }
                         return [...prev, newMessage]
                     })
+                },
+
+                onPollCreate: (data) => {
+                    console.log('[useChatWebSocket] Poll created:', data)
+                    const pollData = data.data || data
+                    const pollMessage = {
+                        id: `poll-${pollData.pollId}`,
+                        messageType: 'POLL_CREATE',
+                        userId: pollData.creatorId,
+                        createdAt: pollData.createdAt || new Date().toISOString(),
+                        isOwn: pollData.creatorId === userId,
+                        data: pollData,
+                    }
+                    setMessages((prev) => [...prev, pollMessage])
+                },
+
+                onPollVote: (data) => {
+                    console.log('[useChatWebSocket] Poll vote:', data)
+                    const voteData = data.data || data
+                    setMessages((prev) =>
+                        prev.map((msg) => {
+                            if (msg.id === `poll-${voteData.pollId}` && msg.data) {
+                                return {
+                                    ...msg,
+                                    data: {
+                                        ...msg.data,
+                                        options: voteData.updatedOptions || msg.data.options,
+                                    },
+                                }
+                            }
+                            return msg
+                        })
+                    )
+                },
+
+                onPollEnd: (data) => {
+                    console.log('[useChatWebSocket] Poll ended:', data)
+                    const endData = data.data || data
+                    setMessages((prev) =>
+                        prev.map((msg) => {
+                            if (msg.id === `poll-${endData.pollId}` && msg.data) {
+                                return {
+                                    ...msg,
+                                    data: {
+                                        ...msg.data,
+                                        isActive: false,
+                                        options: endData.finalResults || msg.data.options,
+                                    },
+                                }
+                            }
+                            return msg
+                        })
+                    )
+                },
+
+                onClearChat: (data) => {
+                    console.log('[useChatWebSocket] Clear chat:', data)
+                    const clearData = data.data || data
+                    // 특정 사용자의 메시지만 삭제
+                    setMessages((prev) =>
+                        prev.filter((msg) => !clearData.messageIds?.includes(msg.id))
+                    )
+                },
+
+                onLeaveRoom: (data) => {
+                    console.log('[useChatWebSocket] User left room:', data)
+                    const leaveData = data.data || data
+                    const systemMessage = {
+                        id: `leave-${Date.now()}`,
+                        content: `${leaveData.userId}님이 채팅방을 나갔습니다.`,
+                        messageType: 'SYSTEM',
+                        createdAt: leaveData.leftAt || new Date().toISOString(),
+                        isSystem: true,
+                    }
+                    setMessages((prev) => [...prev, systemMessage])
+                },
+
+                onSystemCommand: (data) => {
+                    console.log('[useChatWebSocket] System command:', data)
+                    const commandData = data.data || data
+                    const commandMessage = {
+                        id: `syscmd-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`,
+                        messageType: 'SYSTEM_COMMAND',
+                        userId: commandData.userId,
+                        createdAt: new Date().toISOString(),
+                        data: commandData,
+                    }
+                    setMessages((prev) => [...prev, commandMessage])
                 },
 
                 onGameStart: (data) => {

--- a/src/domains/freetalk/pages/ChatRoomPage.jsx
+++ b/src/domains/freetalk/pages/ChatRoomPage.jsx
@@ -25,6 +25,10 @@ import {chatRoomService, messageService, voiceService} from '../../chat/services
 import {useAuth} from '../../../contexts/AuthContext'
 import {useChatWebSocket} from '../hooks/useChatWebSocket'
 import {useThemeMode} from '../../../contexts/ThemeContext'
+import CommandAutocomplete from '../components/CommandAutocomplete'
+import PollCard from '../components/PollCard'
+import SystemCommandMessage from '../components/SystemCommandMessage'
+import {parseCommand, MessageType} from '../types/chatCommandTypes'
 
 const levelColors = {
     beginner: {bg: '#e8f5e9', color: '#2e7d32', label: '초급'},
@@ -51,6 +55,7 @@ const ChatRoomPage = () => {
     const [loading, setLoading] = useState(true)
     const [error, setError] = useState(null)
     const [playingTTS, setPlayingTTS] = useState(null)
+    const [showCommandAutocomplete, setShowCommandAutocomplete] = useState(false)
 
     // WebSocket 훅 사용 (채팅방에서는 게임 관련 기능 제외)
     const {
@@ -153,6 +158,19 @@ const ChatRoomPage = () => {
 
         const messageContent = newMessage.trim()
         setNewMessage('')
+        setShowCommandAutocomplete(false)
+
+        // 명령어 파싱
+        const {isCommand, command, args} = parseCommand(messageContent)
+
+        // /leave 명령어는 클라이언트에서 직접 처리
+        if (isCommand && command === '/leave') {
+            handleLeaveRoom()
+            return
+        }
+
+        // /clear 명령어는 서버로 전송 (서버에서 처리)
+        // 나머지 명령어들도 서버로 전송하여 처리
 
         // WebSocket으로 전송
         if (isConnected) {
@@ -216,6 +234,41 @@ const ChatRoomPage = () => {
         } catch (err) {
             console.error('Failed to leave room:', err)
             setError('채팅방 퇴장에 실패했습니다')
+        }
+    }
+
+    // 투표하기
+    const handleVote = (pollId, optionId) => {
+        if (isConnected) {
+            wsSendMessage(`/vote ${pollId} ${optionId}`, 'TEXT')
+        }
+    }
+
+    // 투표 종료
+    const handleEndPoll = (pollId) => {
+        if (isConnected) {
+            wsSendMessage(`/endpoll ${pollId}`, 'TEXT')
+        }
+    }
+
+    // 명령어 자동완성 선택
+    const handleCommandSelect = (command) => {
+        if (command) {
+            setNewMessage(command + ' ')
+        }
+        setShowCommandAutocomplete(false)
+    }
+
+    // 입력값 변경 처리
+    const handleInputChange = (e) => {
+        const value = e.target.value
+        setNewMessage(value)
+
+        // "/" 입력 시 자동완성 표시
+        if (value.startsWith('/') && value.length > 0) {
+            setShowCommandAutocomplete(true)
+        } else {
+            setShowCommandAutocomplete(false)
         }
     }
 
@@ -323,100 +376,124 @@ const ChatRoomPage = () => {
                         </Typography>
                     </Box>
                 ) : (
-                    messages.map((message) => (
-                        <Box
-                            key={message.id}
-                            sx={{
-                                display: 'flex',
-                                flexDirection: message.isOwn ? 'row-reverse' : 'row',
-                                alignItems: 'flex-end',
-                                gap: 1,
-                            }}
-                        >
-                            {/* 시스템 메시지 */}
-                            {message.isSystem ? (
-                                <Box sx={{width: '100%', textAlign: 'center', py: 0.5}}>
-                                    <Typography variant="caption" color="text.secondary">
-                                        {message.content}
-                                    </Typography>
+                    messages.map((message) => {
+                        // 투표 메시지
+                        if (message.messageType === MessageType.POLL_CREATE) {
+                            return (
+                                <Box key={message.id} sx={{width: '100%', display: 'flex', justifyContent: 'center', py: 1}}>
+                                    <PollCard
+                                        poll={message.data}
+                                        currentUserId={currentUserId}
+                                        onVote={handleVote}
+                                        onEndPoll={handleEndPoll}
+                                    />
                                 </Box>
-                            ) : (
-                                <>
-                                    {/* 아바타 (상대방만) */}
-                                    {!message.isOwn && (
-                                        <Avatar sx={{width: 36, height: 36, bgcolor: 'primary.main'}}>
-                                            {message.userId?.charAt(0)?.toUpperCase() || 'U'}
-                                        </Avatar>
-                                    )}
+                            )
+                        }
 
-                                    <Box
-                                        sx={{
-                                            display: 'flex',
-                                            flexDirection: 'column',
-                                            alignItems: message.isOwn ? 'flex-end' : 'flex-start',
-                                            maxWidth: '70%',
-                                        }}
-                                    >
-                                        {/* 사용자 이름 (상대방만) */}
+                        // 시스템 명령어 메시지
+                        if (message.messageType === MessageType.SYSTEM_COMMAND) {
+                            return (
+                                <SystemCommandMessage key={message.id} data={message.data}/>
+                            )
+                        }
+
+                        // 일반 메시지
+                        return (
+                            <Box
+                                key={message.id}
+                                sx={{
+                                    display: 'flex',
+                                    flexDirection: message.isOwn ? 'row-reverse' : 'row',
+                                    alignItems: 'flex-end',
+                                    gap: 1,
+                                }}
+                            >
+                                {/* 시스템 메시지 */}
+                                {message.isSystem ? (
+                                    <Box sx={{width: '100%', textAlign: 'center', py: 0.5}}>
+                                        <Typography variant="caption" color="text.secondary">
+                                            {message.content}
+                                        </Typography>
+                                    </Box>
+                                ) : (
+                                    <>
+                                        {/* 아바타 (상대방만) */}
                                         {!message.isOwn && (
-                                            <Typography variant="caption" sx={{mb: 0.5, ml: 1}}>
-                                                {message.userId}
-                                            </Typography>
+                                            <Avatar sx={{width: 36, height: 36, bgcolor: 'primary.main'}}>
+                                                {message.userId?.charAt(0)?.toUpperCase() || 'U'}
+                                            </Avatar>
                                         )}
 
-                                        {/* 메시지 버블 */}
-                                        <Box sx={{display: 'flex', alignItems: 'flex-end', gap: 0.5}}>
-                                            {message.isOwn && (
-                                                <Typography variant="caption" color="text.secondary">
-                                                    {formatTime(message.createdAt)}
+                                        <Box
+                                            sx={{
+                                                display: 'flex',
+                                                flexDirection: 'column',
+                                                alignItems: message.isOwn ? 'flex-end' : 'flex-start',
+                                                maxWidth: '70%',
+                                            }}
+                                        >
+                                            {/* 사용자 이름 (상대방만) */}
+                                            {!message.isOwn && (
+                                                <Typography variant="caption" sx={{mb: 0.5, ml: 1}}>
+                                                    {message.userId}
                                                 </Typography>
                                             )}
 
-                                            <Paper
-                                                elevation={0}
-                                                sx={{
-                                                    px: 1.5,
-                                                    py: 1,
-                                                    bgcolor: message.isOwn
-                                                        ? (isDark ? '#facc15' : '#fee500')
-                                                        : (isDark ? '#374151' : '#ffffff'),
-                                                    color: message.isOwn
-                                                        ? '#1c1917'
-                                                        : (isDark ? '#fafaf9' : 'inherit'),
-                                                    borderRadius: message.isOwn ? '12px 12px 0 12px' : '12px 12px 12px 0',
-                                                    opacity: message.isPending ? 0.7 : 1,
-                                                }}
-                                            >
-                                                <Typography variant="body2" sx={{whiteSpace: 'pre-wrap'}}>
-                                                    {message.content}
-                                                </Typography>
-                                            </Paper>
-
-                                            {!message.isOwn && (
-                                                <Box sx={{display: 'flex', alignItems: 'center', gap: 0.5}}>
-                                                    <IconButton
-                                                        size="small"
-                                                        onClick={() => handlePlayTTS(message.id)}
-                                                        disabled={playingTTS === message.id}
-                                                        sx={{p: 0.5}}
-                                                    >
-                                                        {playingTTS === message.id ? (
-                                                            <CircularProgress size={16}/>
-                                                        ) : (
-                                                            <VolumeUpIcon fontSize="small"/>
-                                                        )}
-                                                    </IconButton>
+                                            {/* 메시지 버블 */}
+                                            <Box sx={{display: 'flex', alignItems: 'flex-end', gap: 0.5}}>
+                                                {message.isOwn && (
                                                     <Typography variant="caption" color="text.secondary">
                                                         {formatTime(message.createdAt)}
                                                     </Typography>
-                                                </Box>
-                                            )}
+                                                )}
+
+                                                <Paper
+                                                    elevation={0}
+                                                    sx={{
+                                                        px: 1.5,
+                                                        py: 1,
+                                                        bgcolor: message.isOwn
+                                                            ? (isDark ? '#facc15' : '#fee500')
+                                                            : (isDark ? '#374151' : '#ffffff'),
+                                                        color: message.isOwn
+                                                            ? '#1c1917'
+                                                            : (isDark ? '#fafaf9' : 'inherit'),
+                                                        borderRadius: message.isOwn ? '12px 12px 0 12px' : '12px 12px 12px 0',
+                                                        opacity: message.isPending ? 0.7 : 1,
+                                                    }}
+                                                >
+                                                    <Typography variant="body2" sx={{whiteSpace: 'pre-wrap'}}>
+                                                        {message.content}
+                                                    </Typography>
+                                                </Paper>
+
+                                                {!message.isOwn && (
+                                                    <Box sx={{display: 'flex', alignItems: 'center', gap: 0.5}}>
+                                                        <IconButton
+                                                            size="small"
+                                                            onClick={() => handlePlayTTS(message.id)}
+                                                            disabled={playingTTS === message.id}
+                                                            sx={{p: 0.5}}
+                                                        >
+                                                            {playingTTS === message.id ? (
+                                                                <CircularProgress size={16}/>
+                                                            ) : (
+                                                                <VolumeUpIcon fontSize="small"/>
+                                                            )}
+                                                        </IconButton>
+                                                        <Typography variant="caption" color="text.secondary">
+                                                            {formatTime(message.createdAt)}
+                                                        </Typography>
+                                                    </Box>
+                                                )}
+                                            </Box>
                                         </Box>
-                                    </Box>
-                                </>
-                            )}
-                        </Box>
-                    ))
+                                    </>
+                                )}
+                            </Box>
+                        )
+                    })
                 )}
                 <div ref={messagesEndRef}/>
             </Box>
@@ -430,13 +507,21 @@ const ChatRoomPage = () => {
                     alignItems: 'center',
                     gap: 1,
                     borderRadius: 0,
+                    position: 'relative',
                 }}
             >
+                {/* 명령어 자동완성 */}
+                <CommandAutocomplete
+                    input={newMessage}
+                    onSelect={handleCommandSelect}
+                    show={showCommandAutocomplete}
+                />
+
                 <TextField
                     fullWidth
-                    placeholder={isConnected ? '메시지를 입력하세요...' : '연결 중...'}
+                    placeholder={isConnected ? '메시지를 입력하세요... ("/" 입력 시 명령어 보기)' : '연결 중...'}
                     value={newMessage}
-                    onChange={(e) => setNewMessage(e.target.value)}
+                    onChange={handleInputChange}
                     onKeyPress={handleKeyPress}
                     size="small"
                     multiline

--- a/src/domains/freetalk/services/chatWebSocketService.js
+++ b/src/domains/freetalk/services/chatWebSocketService.js
@@ -177,8 +177,33 @@ class ChatWebSocketConnection {
                 break
             case 'system_command':
             case 'SYSTEM_COMMAND':
-                // 시스템 명령어 응답 (예: /member, /help 등)
-                this.callbacks.onMessage?.(data)
+                // 시스템 명령어 응답 (예: /dice, /coin, /random, /members, /help 등)
+                this.callbacks.onSystemCommand?.(data)
+                break
+            case 'poll_create':
+            case 'POLL_CREATE':
+                console.log('[ChatWebSocket] Poll create received:', data)
+                this.callbacks.onPollCreate?.(data)
+                break
+            case 'poll_vote':
+            case 'POLL_VOTE':
+                console.log('[ChatWebSocket] Poll vote received:', data)
+                this.callbacks.onPollVote?.(data)
+                break
+            case 'poll_end':
+            case 'POLL_END':
+                console.log('[ChatWebSocket] Poll end received:', data)
+                this.callbacks.onPollEnd?.(data)
+                break
+            case 'clear_chat':
+            case 'CLEAR_CHAT':
+                console.log('[ChatWebSocket] Clear chat received:', data)
+                this.callbacks.onClearChat?.(data)
+                break
+            case 'leave_room':
+            case 'LEAVE_ROOM':
+                console.log('[ChatWebSocket] Leave room received:', data)
+                this.callbacks.onLeaveRoom?.(data)
                 break
             case 'error':
             case 'ERROR':

--- a/src/domains/freetalk/types/chatCommandTypes.js
+++ b/src/domains/freetalk/types/chatCommandTypes.js
@@ -1,0 +1,219 @@
+/**
+ * 채팅 메시지 타입 상수
+ * @enum {string}
+ */
+export const MessageType = {
+  TEXT: 'TEXT',
+  IMAGE: 'IMAGE',
+  VOICE: 'VOICE',
+  SYSTEM_COMMAND: 'SYSTEM_COMMAND',
+  POLL_CREATE: 'POLL_CREATE',
+  POLL_VOTE: 'POLL_VOTE',
+  POLL_END: 'POLL_END',
+  CLEAR_CHAT: 'CLEAR_CHAT',
+  LEAVE_ROOM: 'LEAVE_ROOM',
+}
+
+/**
+ * 사용 가능한 채팅 명령어 목록
+ */
+export const COMMANDS = [
+  {
+    command: '/help',
+    description: '사용 가능한 명령어 목록 보기',
+    usage: '/help',
+  },
+  {
+    command: '/members',
+    description: '현재 참여 중인 멤버 목록 보기',
+    usage: '/members',
+  },
+  {
+    command: '/poll',
+    description: '투표 생성하기',
+    usage: '/poll [질문] [옵션1] [옵션2] ...',
+  },
+  {
+    command: '/vote',
+    description: '투표하기',
+    usage: '/vote [투표ID] [옵션번호]',
+  },
+  {
+    command: '/endpoll',
+    description: '투표 종료하기',
+    usage: '/endpoll [투표ID]',
+  },
+  {
+    command: '/clear',
+    description: '내 메시지 모두 삭제',
+    usage: '/clear',
+  },
+  {
+    command: '/leave',
+    description: '채팅방 나가기',
+    usage: '/leave',
+  },
+  {
+    command: '/dice',
+    description: '주사위 굴리기 (1-6)',
+    usage: '/dice',
+  },
+  {
+    command: '/coin',
+    description: '동전 던지기 (앞면/뒷면)',
+    usage: '/coin',
+  },
+  {
+    command: '/random',
+    description: '무작위 숫자 생성',
+    usage: '/random [최소값] [최대값]',
+  },
+]
+
+/**
+ * @typedef {Object} PollOption
+ * @property {number} optionId - 옵션 ID
+ * @property {string} text - 옵션 텍스트
+ * @property {number} voteCount - 투표 수
+ * @property {string[]} voters - 투표한 사용자 ID 목록
+ */
+
+/**
+ * @typedef {Object} PollCreateData
+ * @property {string} pollId - 투표 ID
+ * @property {string} question - 투표 질문
+ * @property {PollOption[]} options - 투표 옵션 목록
+ * @property {string} creatorId - 생성자 ID
+ * @property {string} createdAt - ISO-8601 생성 시간
+ * @property {boolean} isActive - 활성 상태
+ */
+
+/**
+ * @typedef {Object} PollVoteData
+ * @property {string} pollId - 투표 ID
+ * @property {number} optionId - 선택한 옵션 ID
+ * @property {string} userId - 투표한 사용자 ID
+ * @property {PollOption[]} updatedOptions - 업데이트된 옵션 목록
+ */
+
+/**
+ * @typedef {Object} PollEndData
+ * @property {string} pollId - 투표 ID
+ * @property {PollOption[]} finalResults - 최종 결과
+ * @property {string} endedBy - 종료한 사용자 ID
+ * @property {string} endedAt - ISO-8601 종료 시간
+ */
+
+/**
+ * @typedef {Object} SystemCommandData
+ * @property {string} commandType - 명령어 타입 (dice, coin, random, members, help)
+ * @property {string} userId - 명령어 실행 사용자 ID
+ * @property {Object} result - 명령어 실행 결과
+ * @property {string} displayText - 표시할 텍스트
+ */
+
+/**
+ * @typedef {Object} ClearChatData
+ * @property {string} userId - 삭제 요청 사용자 ID
+ * @property {string[]} messageIds - 삭제된 메시지 ID 목록
+ */
+
+/**
+ * @typedef {Object} LeaveRoomData
+ * @property {string} userId - 퇴장한 사용자 ID
+ * @property {string} roomId - 방 ID
+ * @property {string} leftAt - ISO-8601 퇴장 시간
+ */
+
+/**
+ * @typedef {Object} MembersListData
+ * @property {string[]} memberIds - 멤버 ID 목록
+ * @property {number} totalCount - 총 멤버 수
+ */
+
+/**
+ * 명령어 파싱 유틸리티
+ * @param {string} message - 입력된 메시지
+ * @returns {{isCommand: boolean, command: string, args: string[]}}
+ */
+export function parseCommand(message) {
+  const trimmed = message.trim()
+
+  if (!trimmed.startsWith('/')) {
+    return { isCommand: false, command: '', args: [] }
+  }
+
+  const parts = trimmed.split(/\s+/)
+  const command = parts[0].toLowerCase()
+  const args = parts.slice(1)
+
+  return {
+    isCommand: true,
+    command,
+    args,
+  }
+}
+
+/**
+ * 명령어가 유효한지 확인
+ * @param {string} command - 명령어 (예: '/help')
+ * @returns {boolean}
+ */
+export function isValidCommand(command) {
+  return COMMANDS.some(cmd => cmd.command === command.toLowerCase())
+}
+
+/**
+ * 명령어 검색 (자동완성용)
+ * @param {string} input - 사용자 입력
+ * @returns {Array} 일치하는 명령어 목록
+ */
+export function searchCommands(input) {
+  const lowerInput = input.toLowerCase()
+  return COMMANDS.filter(cmd => cmd.command.startsWith(lowerInput))
+}
+
+/**
+ * 투표 결과 계산
+ * @param {PollOption[]} options - 투표 옵션 목록
+ * @returns {{totalVotes: number, percentages: number[]}}
+ */
+export function calculatePollResults(options) {
+  const totalVotes = options.reduce((sum, opt) => sum + opt.voteCount, 0)
+  const percentages = options.map(opt =>
+    totalVotes > 0 ? Math.round((opt.voteCount / totalVotes) * 100) : 0
+  )
+
+  return { totalVotes, percentages }
+}
+
+/**
+ * 시스템 명령어 아이콘 및 색상 설정
+ */
+export const SystemCommandConfig = {
+  dice: {
+    icon: '🎲',
+    color: '#8b5cf6',
+    bgColor: '#f5f3ff',
+  },
+  coin: {
+    icon: '🪙',
+    color: '#f59e0b',
+    bgColor: '#fffbeb',
+  },
+  random: {
+    icon: '🔢',
+    color: '#06b6d4',
+    bgColor: '#ecfeff',
+  },
+  members: {
+    icon: '👥',
+    color: '#10b981',
+    bgColor: '#ecfdf5',
+  },
+  help: {
+    icon: '❓',
+    color: '#6366f1',
+    bgColor: '#eef2ff',
+  },
+}


### PR DESCRIPTION
## Summary
- 채팅방에서 슬래시 명령어 시스템 구현
- `/` 입력 시 명령어 자동완성 UI
- 투표 생성/참여/종료 인터랙티브 UI
- 주사위, 동전, 랜덤 선택 등 재미 명령어 지원

## 지원 명령어

### 기본 명령어
| 명령어 | 설명 |
|--------|------|
| `/help` | 명령어 목록 표시 |
| `/members` | 접속자 목록 조회 |
| `/leave` | 채팅방 퇴장 |
| `/clear` | 채팅 내역 삭제 |

### 재미 명령어
| 명령어 | 설명 |
|--------|------|
| `/dice` | 주사위 굴리기 (1-6) |
| `/coin` | 동전 던지기 |
| `/random [옵션1] [옵션2] ...` | 랜덤 선택 |

### 투표 명령어
| 명령어 | 설명 |
|--------|------|
| `/poll [질문] \| [옵션1] \| [옵션2]` | 투표 생성 |
| `/vote [번호]` | 투표 참여 |
| `/endpoll` | 투표 종료 |

## 새로 추가된 파일
- `types/chatCommandTypes.js` - 명령어 타입 정의
- `components/CommandAutocomplete.jsx` - 자동완성 UI
- `components/PollCard.jsx` - 투표 카드 UI
- `components/PollResultBar.jsx` - 투표 결과 바
- `components/SystemCommandMessage.jsx` - 시스템 명령어 결과

## Test plan
- [ ] `/` 입력 시 명령어 목록 표시 확인
- [ ] 명령어 선택 시 입력창에 자동 입력
- [ ] `/poll 점심 뭐먹지? | 짜장 | 짬뽕` 입력 후 투표 카드 표시
- [ ] 투표 버튼 클릭 시 투표 반영
- [ ] `/dice`, `/coin` 결과 표시