### PR TITLE
[FEAT] 영어 끝말잇기(Word Chain) 게임 구현 (#205)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -32,6 +32,9 @@ import { BadgeSection } from './domains/badge'
 import CatchmindLobbyPage from './domains/games/pages/CatchmindLobbyPage'
 import CatchmindWaitingPage from './domains/games/pages/CatchmindWaitingPage'
 import CatchmindPlayPage from './domains/games/pages/CatchmindPlayPage'
+import WordchainLobbyPage from './domains/games/pages/WordchainLobbyPage'
+import WordchainWaitingPage from './domains/games/pages/WordchainWaitingPage'
+import WordchainPlayPage from './domains/games/pages/WordchainPlayPage'
 import { NewsListPage, NewsDetailPage, NewsQuizPage, NewsWordsPage, NewsStatsPage } from './domains/news'
 import { dailyService, statsService } from './domains/vocab/services/vocabService'
 import { getNewsStats, getDashboardStats } from './domains/news/services/newsService'
@@ -268,6 +271,13 @@ function Dashboard() {
                     icon: GameIcon,
                     path: '/games/catchmind',
                     description: t('games.catchmindDesc')
+                },
+                {
+                    id: 'wordchain',
+                    title: '끝말잇기',
+                    icon: GameIcon,
+                    path: '/games/wordchain',
+                    description: '영어 끝말잇기'
                 },
             ],
         },
@@ -1176,6 +1186,9 @@ function App() {
                     <Route path="/games/catchmind" element={<CatchmindLobbyPage />} />
                     <Route path="/games/catchmind/:roomId/waiting" element={<CatchmindWaitingPage />} />
                     <Route path="/games/catchmind/:roomId/play" element={<CatchmindPlayPage />} />
+                    <Route path="/games/wordchain" element={<WordchainLobbyPage />} />
+                    <Route path="/games/wordchain/:roomId/waiting" element={<WordchainWaitingPage />} />
+                    <Route path="/games/wordchain/:roomId/play" element={<WordchainPlayPage />} />
                     <Route path="/news" element={<NewsListPage />} />
                     <Route path="/news/:articleId" element={<NewsDetailPage />} />
                     <Route path="/news/:articleId/quiz" element={<NewsQuizPage />} />

--- a/src/domains/freetalk/services/chatWebSocketService.js
+++ b/src/domains/freetalk/services/chatWebSocketService.js
@@ -213,6 +213,31 @@ class ChatWebSocketConnection {
                 // 추측 메시지 - 일반 메시지로 처리
                 this.callbacks.onMessage?.(data)
                 break
+            case 'wordchain_start':
+            case 'WORDCHAIN_START':
+                console.log('[ChatWebSocket] Wordchain start received:', data)
+                this.callbacks.onWordchainStart?.(data)
+                break
+            case 'wordchain_correct':
+            case 'WORDCHAIN_CORRECT':
+                console.log('[ChatWebSocket] Wordchain correct received:', data)
+                this.callbacks.onWordchainCorrect?.(data)
+                break
+            case 'wordchain_wrong':
+            case 'WORDCHAIN_WRONG':
+                console.log('[ChatWebSocket] Wordchain wrong received:', data)
+                this.callbacks.onWordchainWrong?.(data)
+                break
+            case 'wordchain_timeout':
+            case 'WORDCHAIN_TIMEOUT':
+                console.log('[ChatWebSocket] Wordchain timeout received:', data)
+                this.callbacks.onWordchainTimeout?.(data)
+                break
+            case 'wordchain_end':
+            case 'WORDCHAIN_END':
+                console.log('[ChatWebSocket] Wordchain end received:', data)
+                this.callbacks.onWordchainEnd?.(data)
+                break
             default:
                 console.log('[ChatWebSocket] Unknown message type:', type || messageType, data)
                 this.callbacks.onMessage?.(data)

--- a/src/domains/games/components/wordchain/GameEndModal.jsx
+++ b/src/domains/games/components/wordchain/GameEndModal.jsx
@@ -1,0 +1,158 @@
+import {
+    Dialog,
+    DialogTitle,
+    DialogContent,
+    DialogActions,
+    Button,
+    Box,
+    Typography,
+} from '@mui/material'
+import {
+    EmojiEvents as TrophyIcon,
+    ExitToApp as ExitIcon,
+    Replay as ReplayIcon,
+} from '@mui/icons-material'
+import { GAME_COLORS, GAME_TYPOGRAPHY } from '../../theme/gameTheme'
+
+/**
+ * GameEndModal - 게임 종료 모달
+ */
+const GameEndModal = ({ open, winner, finalPlayers, onRestart, onExit, currentUserId }) => {
+    const sortedPlayers = [...(finalPlayers || [])]
+        .sort((a, b) => {
+            // 생존자가 우선
+            if (a.isAlive && !b.isAlive) return -1
+            if (!a.isAlive && b.isAlive) return 1
+            // 제출한 단어 수로 정렬
+            return (b.wordsSubmitted || 0) - (a.wordsSubmitted || 0)
+        })
+
+    return (
+        <Dialog
+            open={open}
+            maxWidth="sm"
+            fullWidth
+            PaperProps={{
+                sx: { borderRadius: '20px' },
+            }}
+        >
+            <DialogTitle
+                sx={{
+                    bgcolor: GAME_COLORS.primary,
+                    color: 'white',
+                    textAlign: 'center',
+                    py: 3,
+                }}
+            >
+                <TrophyIcon sx={{ fontSize: 48, mb: 1 }} />
+                <Typography variant="h5" fontWeight={700}>
+                    게임 종료!
+                </Typography>
+            </DialogTitle>
+
+            <DialogContent sx={{ py: 3 }}>
+                {winner && (
+                    <Box
+                        sx={{
+                            textAlign: 'center',
+                            mb: 3,
+                            p: 3,
+                            borderRadius: '16px',
+                            bgcolor: '#FEF3C7',
+                        }}
+                    >
+                        <Typography variant="h6" fontWeight={700} color="#92400E" gutterBottom>
+                            우승자
+                        </Typography>
+                        <Typography variant="h4" fontWeight={800} color="#F59E0B">
+                            {winner.nickname || winner.userId}
+                            {winner.userId === currentUserId && ' (나)'}
+                        </Typography>
+                    </Box>
+                )}
+
+                <Typography variant="h6" fontWeight={700} textAlign="center" gutterBottom>
+                    최종 순위
+                </Typography>
+
+                <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.5, mt: 2 }}>
+                    {sortedPlayers.map((player, index) => (
+                        <Box
+                            key={player.userId}
+                            sx={{
+                                display: 'flex',
+                                alignItems: 'center',
+                                justifyContent: 'space-between',
+                                p: 2,
+                                bgcolor: player.isAlive
+                                    ? index === 0
+                                        ? '#FEF3C7'
+                                        : index === 1
+                                        ? '#F3F4F6'
+                                        : index === 2
+                                        ? '#FED7AA'
+                                        : 'transparent'
+                                    : '#FEE2E2',
+                                borderRadius: '12px',
+                                border: '1px solid',
+                                borderColor: 'divider',
+                            }}
+                        >
+                            <Box sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
+                                <Typography
+                                    sx={{
+                                        fontSize: '1.5rem',
+                                        fontWeight: 700,
+                                    }}
+                                >
+                                    {player.isAlive ? (
+                                        index === 0 ? '🥇' : index === 1 ? '🥈' : index === 2 ? '🥉' : `${index + 1}위`
+                                    ) : '❌'}
+                                </Typography>
+                                <Typography variant="body1" fontWeight={600}>
+                                    {player.nickname || player.userId}
+                                    {player.userId === currentUserId && ' (나)'}
+                                </Typography>
+                            </Box>
+                            <Typography
+                                sx={{
+                                    ...GAME_TYPOGRAPHY.score,
+                                    fontSize: '1rem',
+                                    color: player.isAlive ? GAME_COLORS.primary : 'text.secondary',
+                                }}
+                            >
+                                {player.wordsSubmitted || 0}단어
+                            </Typography>
+                        </Box>
+                    ))}
+                </Box>
+            </DialogContent>
+
+            <DialogActions sx={{ p: 2, gap: 1 }}>
+                <Button
+                    startIcon={<ExitIcon />}
+                    onClick={onExit}
+                    sx={{ borderRadius: '10px', textTransform: 'none' }}
+                >
+                    나가기
+                </Button>
+                <Button
+                    variant="contained"
+                    startIcon={<ReplayIcon />}
+                    onClick={onRestart}
+                    sx={{
+                        bgcolor: GAME_COLORS.primary,
+                        '&:hover': { bgcolor: GAME_COLORS.primaryLight },
+                        borderRadius: '10px',
+                        textTransform: 'none',
+                        fontWeight: 600,
+                    }}
+                >
+                    다시하기
+                </Button>
+            </DialogActions>
+        </Dialog>
+    )
+}
+
+export default GameEndModal

--- a/src/domains/games/components/wordchain/PlayerList.jsx
+++ b/src/domains/games/components/wordchain/PlayerList.jsx
@@ -1,0 +1,89 @@
+import { Box, Typography, Avatar } from '@mui/material'
+import { CheckCircle as CheckIcon } from '@mui/icons-material'
+import { GAME_COLORS } from '../../theme/gameTheme'
+import { useThemeMode } from '../../../../contexts/ThemeContext'
+
+/**
+ * PlayerList - 플레이어 목록 (턴 & 생존 상태)
+ */
+const PlayerList = ({ players, currentTurnUserId, currentUserId }) => {
+    const { mode } = useThemeMode()
+    const isDark = mode === 'dark'
+
+    return (
+        <Box>
+            <Typography variant="subtitle2" fontWeight={700} color="text.secondary" gutterBottom>
+                플레이어
+            </Typography>
+            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
+                {players.map((player) => {
+                    const isCurrentTurn = player.userId === currentTurnUserId
+                    const isMe = player.userId === currentUserId
+                    const isAlive = player.isAlive !== false
+
+                    return (
+                        <Box
+                            key={player.userId}
+                            sx={{
+                                display: 'flex',
+                                alignItems: 'center',
+                                gap: 1.5,
+                                p: 1.5,
+                                borderRadius: '12px',
+                                bgcolor: isCurrentTurn
+                                    ? GAME_COLORS.primaryBg
+                                    : isMe
+                                    ? isDark ? 'rgba(255,255,255,0.05)' : 'rgba(0,0,0,0.03)'
+                                    : 'transparent',
+                                border: '2px solid',
+                                borderColor: isCurrentTurn ? GAME_COLORS.primary : 'transparent',
+                                opacity: isAlive ? 1 : 0.5,
+                                transition: 'all 0.2s ease',
+                            }}
+                        >
+                            <Avatar
+                                sx={{
+                                    width: 36,
+                                    height: 36,
+                                    bgcolor: isCurrentTurn ? GAME_COLORS.primary : '#9CA3AF',
+                                    fontSize: '0.875rem',
+                                }}
+                            >
+                                {player.nickname?.[0] || player.userId?.[0] || '?'}
+                            </Avatar>
+                            <Box sx={{ flex: 1, minWidth: 0 }}>
+                                <Typography
+                                    variant="body2"
+                                    fontWeight={isCurrentTurn ? 700 : 500}
+                                    sx={{
+                                        overflow: 'hidden',
+                                        textOverflow: 'ellipsis',
+                                        whiteSpace: 'nowrap',
+                                    }}
+                                >
+                                    {player.nickname || player.userId}
+                                    {isMe && ' (나)'}
+                                </Typography>
+                                {isCurrentTurn && (
+                                    <Typography variant="caption" color={GAME_COLORS.primary} fontWeight={600}>
+                                        턴 진행 중
+                                    </Typography>
+                                )}
+                            </Box>
+                            {!isAlive && (
+                                <Typography variant="caption" color="error" fontWeight={600}>
+                                    탈락
+                                </Typography>
+                            )}
+                            {isAlive && !isCurrentTurn && player.hasAnswered && (
+                                <CheckIcon sx={{ fontSize: 20, color: GAME_COLORS.status.waiting }} />
+                            )}
+                        </Box>
+                    )
+                })}
+            </Box>
+        </Box>
+    )
+}
+
+export default PlayerList

--- a/src/domains/games/components/wordchain/UsedWordsList.jsx
+++ b/src/domains/games/components/wordchain/UsedWordsList.jsx
@@ -1,0 +1,49 @@
+import { Box, Typography, Chip } from '@mui/material'
+import { GAME_COLORS } from '../../theme/gameTheme'
+
+/**
+ * UsedWordsList - 사용된 단어 목록
+ */
+const UsedWordsList = ({ words }) => {
+    return (
+        <Box>
+            <Typography variant="subtitle2" fontWeight={700} color="text.secondary" gutterBottom>
+                사용된 단어 ({words.length})
+            </Typography>
+            <Box
+                sx={{
+                    display: 'flex',
+                    flexWrap: 'wrap',
+                    gap: 1,
+                    maxHeight: 200,
+                    overflowY: 'auto',
+                    p: 1,
+                    bgcolor: 'rgba(0,0,0,0.02)',
+                    borderRadius: '12px',
+                }}
+            >
+                {words.length === 0 ? (
+                    <Typography variant="caption" color="text.secondary">
+                        아직 사용된 단어가 없습니다
+                    </Typography>
+                ) : (
+                    words.map((wordData, index) => (
+                        <Chip
+                            key={index}
+                            label={wordData.word || wordData}
+                            size="small"
+                            sx={{
+                                bgcolor: GAME_COLORS.primaryBg,
+                                color: GAME_COLORS.primary,
+                                fontWeight: 600,
+                                fontSize: '0.75rem',
+                            }}
+                        />
+                    ))
+                )}
+            </Box>
+        </Box>
+    )
+}
+
+export default UsedWordsList

--- a/src/domains/games/components/wordchain/WordDisplay.jsx
+++ b/src/domains/games/components/wordchain/WordDisplay.jsx
@@ -1,0 +1,73 @@
+import { Box, Typography } from '@mui/material'
+import { GAME_COLORS, GAME_TYPOGRAPHY } from '../../theme/gameTheme'
+import { useThemeMode } from '../../../../contexts/ThemeContext'
+
+/**
+ * WordDisplay - 현재 단어 & 다음 글자 표시
+ */
+const WordDisplay = ({ currentWord, nextLetter, isMyTurn }) => {
+    const { mode } = useThemeMode()
+    const isDark = mode === 'dark'
+
+    return (
+        <Box
+            sx={{
+                p: 4,
+                textAlign: 'center',
+                bgcolor: isDark ? '#27272a' : 'white',
+                borderRadius: '20px',
+                border: '2px solid',
+                borderColor: isMyTurn ? GAME_COLORS.primary : 'divider',
+                transition: 'all 0.3s ease',
+            }}
+        >
+            {currentWord ? (
+                <>
+                    <Typography variant="caption" color="text.secondary" gutterBottom>
+                        현재 단어
+                    </Typography>
+                    <Typography
+                        sx={{
+                            ...GAME_TYPOGRAPHY.word,
+                            fontSize: '2.5rem',
+                            color: GAME_COLORS.primary,
+                            mb: 2,
+                        }}
+                    >
+                        {currentWord}
+                    </Typography>
+                    <Box
+                        sx={{
+                            display: 'inline-flex',
+                            alignItems: 'center',
+                            gap: 1,
+                            px: 3,
+                            py: 1.5,
+                            borderRadius: '12px',
+                            bgcolor: GAME_COLORS.primaryBg,
+                        }}
+                    >
+                        <Typography variant="body2" color="text.secondary" fontWeight={600}>
+                            다음 시작 글자:
+                        </Typography>
+                        <Typography
+                            sx={{
+                                ...GAME_TYPOGRAPHY.word,
+                                fontSize: '2rem',
+                                color: GAME_COLORS.primary,
+                            }}
+                        >
+                            {nextLetter}
+                        </Typography>
+                    </Box>
+                </>
+            ) : (
+                <Typography variant="h6" color="text.secondary">
+                    첫 단어를 기다리는 중...
+                </Typography>
+            )}
+        </Box>
+    )
+}
+
+export default WordDisplay

--- a/src/domains/games/components/wordchain/WordInput.jsx
+++ b/src/domains/games/components/wordchain/WordInput.jsx
@@ -1,0 +1,96 @@
+import { useState } from 'react'
+import { Box, TextField, Button, Typography } from '@mui/material'
+import { Send as SendIcon } from '@mui/icons-material'
+import { GAME_COLORS } from '../../theme/gameTheme'
+
+/**
+ * WordInput - 단어 입력 필드
+ */
+const WordInput = ({ onSubmit, disabled, nextLetter, isMyTurn }) => {
+    const [word, setWord] = useState('')
+    const [error, setError] = useState('')
+
+    const handleSubmit = (e) => {
+        e.preventDefault()
+
+        const trimmedWord = word.trim().toLowerCase()
+
+        // 유효성 검사
+        if (!trimmedWord) {
+            setError('단어를 입력하세요')
+            return
+        }
+
+        if (nextLetter && trimmedWord[0] !== nextLetter.toLowerCase()) {
+            setError(`단어는 '${nextLetter}'로 시작해야 합니다`)
+            return
+        }
+
+        // 알파벳만 허용
+        if (!/^[a-z]+$/.test(trimmedWord)) {
+            setError('영어 알파벳만 입력하세요')
+            return
+        }
+
+        setError('')
+        onSubmit(trimmedWord)
+        setWord('')
+    }
+
+    const handleChange = (e) => {
+        setWord(e.target.value)
+        setError('')
+    }
+
+    return (
+        <Box>
+            {!isMyTurn && (
+                <Typography variant="caption" color="text.secondary" sx={{ mb: 1, display: 'block' }}>
+                    다른 플레이어의 턴입니다
+                </Typography>
+            )}
+            <Box
+                component="form"
+                onSubmit={handleSubmit}
+                sx={{
+                    display: 'flex',
+                    gap: 1,
+                }}
+            >
+                <TextField
+                    fullWidth
+                    value={word}
+                    onChange={handleChange}
+                    placeholder={nextLetter ? `${nextLetter}로 시작하는 단어 입력` : '단어 입력'}
+                    disabled={disabled || !isMyTurn}
+                    error={!!error}
+                    helperText={error}
+                    autoComplete="off"
+                    sx={{
+                        '& .MuiOutlinedInput-root': {
+                            borderRadius: '12px',
+                        },
+                    }}
+                />
+                <Button
+                    type="submit"
+                    variant="contained"
+                    disabled={disabled || !isMyTurn || !word.trim()}
+                    sx={{
+                        minWidth: 100,
+                        bgcolor: GAME_COLORS.primary,
+                        '&:hover': { bgcolor: GAME_COLORS.primaryLight },
+                        borderRadius: '12px',
+                        textTransform: 'none',
+                        fontWeight: 600,
+                    }}
+                    endIcon={<SendIcon />}
+                >
+                    제출
+                </Button>
+            </Box>
+        </Box>
+    )
+}
+
+export default WordInput

--- a/src/domains/games/components/wordchain/WordchainTimer.jsx
+++ b/src/domains/games/components/wordchain/WordchainTimer.jsx
@@ -1,0 +1,59 @@
+import { Box, CircularProgress, Typography } from '@mui/material'
+import { GAME_COLORS, GAME_TYPOGRAPHY } from '../../theme/gameTheme'
+
+/**
+ * WordchainTimer - 원형 타이머
+ */
+const WordchainTimer = ({ timeLeft, timeLimit }) => {
+    const percentage = (timeLeft / timeLimit) * 100
+    const isDanger = timeLeft <= 5
+
+    return (
+        <Box
+            sx={{
+                position: 'relative',
+                display: 'inline-flex',
+                animation: isDanger ? 'pulse 1s ease-in-out infinite' : 'none',
+                '@keyframes pulse': {
+                    '0%, 100%': { transform: 'scale(1)' },
+                    '50%': { transform: 'scale(1.05)' },
+                },
+            }}
+        >
+            <CircularProgress
+                variant="determinate"
+                value={percentage}
+                size={80}
+                thickness={4}
+                sx={{
+                    color: isDanger ? GAME_COLORS.timer.danger : GAME_COLORS.timer.normal,
+                    transition: 'color 0.3s ease',
+                }}
+            />
+            <Box
+                sx={{
+                    position: 'absolute',
+                    top: 0,
+                    left: 0,
+                    bottom: 0,
+                    right: 0,
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                }}
+            >
+                <Typography
+                    sx={{
+                        ...GAME_TYPOGRAPHY.timer,
+                        fontSize: '1.5rem',
+                        color: isDanger ? GAME_COLORS.timer.danger : GAME_COLORS.timer.normal,
+                    }}
+                >
+                    {timeLeft}
+                </Typography>
+            </Box>
+        </Box>
+    )
+}
+
+export default WordchainTimer

--- a/src/domains/games/pages/WordchainLobbyPage.jsx
+++ b/src/domains/games/pages/WordchainLobbyPage.jsx
@@ -1,0 +1,312 @@
+import { useCallback, useEffect, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import {
+    Alert,
+    Box,
+    Button,
+    Chip,
+    CircularProgress,
+    Container,
+    FormControlLabel,
+    Grid,
+    IconButton,
+    MenuItem,
+    Select,
+    Switch,
+    Typography,
+} from '@mui/material'
+import {
+    Add as AddIcon,
+    Link as LinkIcon,
+    Refresh as RefreshIcon,
+} from '@mui/icons-material'
+import GameRoomCard from '../components/GameRoomCard'
+import CreateGameRoomModal from '../components/CreateGameRoomModal'
+import { gameService } from '../services/gameService'
+import { GAME_COLORS } from '../theme/gameTheme'
+import { useAuth } from '../../../contexts/AuthContext'
+
+const WordchainLobbyPage = () => {
+    const navigate = useNavigate()
+    const { user } = useAuth()
+
+    const [rooms, setRooms] = useState([])
+    const [loading, setLoading] = useState(true)
+    const [error, setError] = useState(null)
+    const [createModalOpen, setCreateModalOpen] = useState(false)
+    const [creating, setCreating] = useState(false)
+
+    // 필터
+    const [filters, setFilters] = useState({
+        level: '',
+        waitingOnly: true,
+    })
+
+    // 방 목록 조회 - gameType을 WORDCHAIN으로 필터링
+    const fetchRooms = useCallback(async () => {
+        try {
+            setLoading(true)
+            setError(null)
+
+            const params = {}
+            if (filters.level) params.level = filters.level
+            if (filters.waitingOnly) params.status = 'WAITING'
+
+            const response = await gameService.getRooms(params)
+            // WORDCHAIN 타입 필터링
+            const wordchainRooms = (response.data.rooms || []).filter(
+                room => room.gameType === 'WORDCHAIN'
+            )
+            setRooms(wordchainRooms)
+        } catch (err) {
+            console.error('Failed to fetch rooms:', err)
+            setError('방 목록을 불러오는데 실패했습니다')
+        } finally {
+            setLoading(false)
+        }
+    }, [filters])
+
+    useEffect(() => {
+        fetchRooms()
+    }, [fetchRooms])
+
+    // 방 생성
+    const handleCreateRoom = async (data) => {
+        try {
+            setCreating(true)
+            // gameType을 WORDCHAIN으로 설정
+            const response = await gameService.createRoom({
+                ...data,
+                gameType: 'WORDCHAIN',
+            })
+            setCreateModalOpen(false)
+            // 생성된 방의 대기실로 이동
+            navigate(`/games/wordchain/${response.data.roomId}/waiting`)
+        } catch (err) {
+            console.error('Failed to create room:', err)
+            setError('방 생성에 실패했습니다')
+        } finally {
+            setCreating(false)
+        }
+    }
+
+    // 방 참가
+    const handleJoinRoom = async (room) => {
+        try {
+            const response = await gameService.joinRoom(room.roomId)
+            // roomToken을 sessionStorage에 저장 (WebSocket 연결 시 사용)
+            if (response.data?.roomToken) {
+                sessionStorage.setItem(`roomToken_${room.roomId}`, response.data.roomToken)
+            }
+            navigate(`/games/wordchain/${room.roomId}/waiting`)
+        } catch (err) {
+            console.error('Failed to join room:', err)
+            setError(err.message || '방 참가에 실패했습니다')
+        }
+    }
+
+    // 관전
+    const handleSpectateRoom = (room) => {
+        navigate(`/games/wordchain/${room.roomId}/play?spectate=true`)
+    }
+
+    return (
+        <Container maxWidth="lg" sx={{ py: 4 }}>
+            {/* 헤더 */}
+            <Box sx={{ mb: 4 }}>
+                <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, mb: 1 }}>
+                    <Box
+                        sx={{
+                            width: 56,
+                            height: 56,
+                            borderRadius: '16px',
+                            background: `linear-gradient(135deg, ${GAME_COLORS.primary} 0%, ${GAME_COLORS.primaryLight} 100%)`,
+                            display: 'flex',
+                            alignItems: 'center',
+                            justifyContent: 'center',
+                            boxShadow: `0 8px 24px -8px ${GAME_COLORS.primary}60`,
+                        }}
+                    >
+                        <LinkIcon sx={{ fontSize: 32, color: 'white' }} />
+                    </Box>
+                    <Box>
+                        <Typography variant="h4" fontWeight={800}>
+                            끝말잇기
+                        </Typography>
+                        <Typography variant="body2" color="text.secondary">
+                            영어 단어로 끝말잇기를 즐겨보세요
+                        </Typography>
+                    </Box>
+                </Box>
+            </Box>
+
+            {/* 필터 + 액션 */}
+            <Box
+                sx={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'space-between',
+                    flexWrap: 'wrap',
+                    gap: 2,
+                    mb: 3,
+                    p: 2,
+                    bgcolor: 'background.paper',
+                    borderRadius: '16px',
+                    border: '1px solid',
+                    borderColor: 'divider',
+                }}
+            >
+                {/* 필터 */}
+                <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, flexWrap: 'wrap' }}>
+                    <Select
+                        value={filters.level}
+                        onChange={(e) => setFilters(prev => ({ ...prev, level: e.target.value }))}
+                        displayEmpty
+                        size="small"
+                        sx={{
+                            minWidth: 100,
+                            borderRadius: '10px',
+                            '& .MuiOutlinedInput-notchedOutline': {
+                                borderRadius: '10px',
+                            },
+                        }}
+                    >
+                        <MenuItem value="">전체 난이도</MenuItem>
+                        <MenuItem value="BEGINNER">초급</MenuItem>
+                        <MenuItem value="INTERMEDIATE">중급</MenuItem>
+                        <MenuItem value="ADVANCED">고급</MenuItem>
+                    </Select>
+
+                    <FormControlLabel
+                        control={
+                            <Switch
+                                checked={filters.waitingOnly}
+                                onChange={(e) => setFilters(prev => ({ ...prev, waitingOnly: e.target.checked }))}
+                                sx={{
+                                    '& .MuiSwitch-switchBase.Mui-checked': {
+                                        color: GAME_COLORS.primary,
+                                    },
+                                    '& .MuiSwitch-switchBase.Mui-checked + .MuiSwitch-track': {
+                                        bgcolor: GAME_COLORS.primary,
+                                    },
+                                }}
+                            />
+                        }
+                        label={<Typography variant="body2">대기중만</Typography>}
+                    />
+
+                    <IconButton onClick={fetchRooms} disabled={loading}>
+                        <RefreshIcon />
+                    </IconButton>
+
+                    <Chip
+                        label={`${rooms.length}개 방`}
+                        size="small"
+                        sx={{ bgcolor: GAME_COLORS.primaryBg, color: GAME_COLORS.primary, fontWeight: 600 }}
+                    />
+                </Box>
+
+                {/* 방 만들기 버튼 */}
+                <Button
+                    variant="contained"
+                    startIcon={<AddIcon />}
+                    onClick={() => setCreateModalOpen(true)}
+                    sx={{
+                        bgcolor: GAME_COLORS.primary,
+                        '&:hover': { bgcolor: GAME_COLORS.primaryLight },
+                        borderRadius: '12px',
+                        textTransform: 'none',
+                        fontWeight: 600,
+                        px: 3,
+                    }}
+                >
+                    방 만들기
+                </Button>
+            </Box>
+
+            {/* 에러 */}
+            {error && (
+                <Alert severity="error" onClose={() => setError(null)} sx={{ mb: 3, borderRadius: '12px' }}>
+                    {error}
+                </Alert>
+            )}
+
+            {/* 방 목록 */}
+            {loading ? (
+                <Box sx={{ display: 'flex', justifyContent: 'center', py: 8 }}>
+                    <CircularProgress sx={{ color: GAME_COLORS.primary }} />
+                </Box>
+            ) : rooms.length === 0 ? (
+                <Box
+                    sx={{
+                        textAlign: 'center',
+                        py: 8,
+                        bgcolor: 'background.paper',
+                        borderRadius: '20px',
+                        border: '1px solid',
+                        borderColor: 'divider',
+                    }}
+                >
+                    <Box
+                        sx={{
+                            width: 80,
+                            height: 80,
+                            borderRadius: '20px',
+                            bgcolor: GAME_COLORS.primaryBg,
+                            display: 'flex',
+                            alignItems: 'center',
+                            justifyContent: 'center',
+                            mx: 'auto',
+                            mb: 2,
+                        }}
+                    >
+                        <LinkIcon sx={{ fontSize: 40, color: GAME_COLORS.primary }} />
+                    </Box>
+                    <Typography variant="h6" fontWeight={600} gutterBottom>
+                        대기 중인 방이 없습니다
+                    </Typography>
+                    <Typography variant="body2" color="text.secondary" sx={{ mb: 3 }}>
+                        새로운 게임방을 만들어보세요!
+                    </Typography>
+                    <Button
+                        variant="contained"
+                        startIcon={<AddIcon />}
+                        onClick={() => setCreateModalOpen(true)}
+                        sx={{
+                            bgcolor: GAME_COLORS.primary,
+                            '&:hover': { bgcolor: GAME_COLORS.primaryLight },
+                            borderRadius: '12px',
+                            textTransform: 'none',
+                            fontWeight: 600,
+                        }}
+                    >
+                        방 만들기
+                    </Button>
+                </Box>
+            ) : (
+                <Grid container spacing={2}>
+                    {rooms.map((room) => (
+                        <Grid item xs={12} sm={6} md={4} key={room.roomId}>
+                            <GameRoomCard
+                                room={room}
+                                onJoin={handleJoinRoom}
+                                onSpectate={handleSpectateRoom}
+                            />
+                        </Grid>
+                    ))}
+                </Grid>
+            )}
+
+            {/* 방 생성 모달 */}
+            <CreateGameRoomModal
+                open={createModalOpen}
+                onClose={() => setCreateModalOpen(false)}
+                onCreate={handleCreateRoom}
+                loading={creating}
+                gameType="WORDCHAIN"
+            />
+        </Container>
+    )
+}
+
+export default WordchainLobbyPage

--- a/src/domains/games/pages/WordchainPlayPage.jsx
+++ b/src/domains/games/pages/WordchainPlayPage.jsx
@@ -1,0 +1,400 @@
+import { useCallback, useEffect, useState } from 'react'
+import { useNavigate, useParams } from 'react-router-dom'
+import {
+    Alert,
+    Box,
+    Button,
+    Chip,
+    CircularProgress,
+    Container,
+    Grid,
+    IconButton,
+    Typography,
+} from '@mui/material'
+import {
+    ExitToApp as ExitIcon,
+    Stop as StopIcon,
+} from '@mui/icons-material'
+import WordDisplay from '../components/wordchain/WordDisplay'
+import WordchainTimer from '../components/wordchain/WordchainTimer'
+import PlayerList from '../components/wordchain/PlayerList'
+import UsedWordsList from '../components/wordchain/UsedWordsList'
+import WordInput from '../components/wordchain/WordInput'
+import GameEndModal from '../components/wordchain/GameEndModal'
+import { gameService } from '../services/gameService'
+import wordchainService from '../services/wordchainService'
+import { GAME_COLORS } from '../theme/gameTheme'
+import { useAuth } from '../../../contexts/AuthContext'
+import { useThemeMode } from '../../../contexts/ThemeContext'
+import { useChatWebSocket } from '../../freetalk/hooks/useChatWebSocket'
+
+const WordchainPlayPage = () => {
+    const { roomId } = useParams()
+    const navigate = useNavigate()
+    const { user } = useAuth()
+    const { mode } = useThemeMode()
+    const isDark = mode === 'dark'
+    const currentUserId = user?.userId || user?.username || user?.sub
+
+    // WebSocket 연결
+    const {
+        isConnected,
+        gameState: wsGameState,
+        error: wsError,
+        connect,
+        disconnect,
+    } = useChatWebSocket(roomId, currentUserId)
+
+    // 로컬 게임 상태
+    const [gameState, setGameState] = useState({
+        status: 'PLAYING',
+        currentWord: null,
+        nextLetter: null,
+        currentTurnUserId: null,
+        turnStartTime: Date.now(),
+        turnTimeLimit: 15,
+        players: [],
+        usedWords: [],
+        winner: null,
+    })
+
+    const [room, setRoom] = useState(null)
+    const [loading, setLoading] = useState(true)
+    const [timeLeft, setTimeLeft] = useState(15)
+    const [showEndModal, setShowEndModal] = useState(false)
+    const [submitting, setSubmitting] = useState(false)
+
+    const isMyTurn = gameState.currentTurnUserId === currentUserId
+
+    // WebSocket gameState 업데이트 반영
+    useEffect(() => {
+        if (wsGameState) {
+            console.log('[WordchainPlayPage] Received wsGameState:', wsGameState)
+
+            setGameState(prev => ({
+                ...prev,
+                status: wsGameState.status ?? prev.status,
+                currentWord: wsGameState.currentWord ?? prev.currentWord,
+                nextLetter: wsGameState.nextLetter ?? prev.nextLetter,
+                currentTurnUserId: wsGameState.currentTurnUserId ?? prev.currentTurnUserId,
+                turnStartTime: wsGameState.turnStartTime ?? prev.turnStartTime,
+                turnTimeLimit: wsGameState.turnTimeLimit ?? prev.turnTimeLimit ?? 15,
+                players: wsGameState.players ?? prev.players,
+                usedWords: wsGameState.usedWords ?? prev.usedWords,
+                winner: wsGameState.winner ?? prev.winner,
+            }))
+
+            // 턴이 변경되면 타이머 리셋
+            if (wsGameState.currentTurnUserId && wsGameState.currentTurnUserId !== prev.currentTurnUserId) {
+                setTimeLeft(wsGameState.turnTimeLimit ?? 15)
+            }
+
+            // 게임 종료 처리
+            if (wsGameState.status === 'FINISHED' && !showEndModal) {
+                setShowEndModal(true)
+            }
+        }
+    }, [wsGameState, showEndModal])
+
+    // 초기 로드 및 WebSocket 연결
+    useEffect(() => {
+        const initGame = async () => {
+            try {
+                setLoading(true)
+
+                // 방 정보 조회
+                const roomResponse = await gameService.getRoom(roomId)
+                setRoom(roomResponse.data)
+
+                // 게임 상태 조회
+                let gameData
+                try {
+                    const statusResponse = await wordchainService.getStatus(roomId)
+                    gameData = statusResponse.data || statusResponse
+                } catch {
+                    // 게임 상태가 없으면 시작
+                    const gameResponse = await wordchainService.start(roomId)
+                    gameData = gameResponse.data || gameResponse
+                }
+
+                setGameState({
+                    status: 'PLAYING',
+                    currentWord: gameData.currentWord || null,
+                    nextLetter: gameData.nextLetter || null,
+                    currentTurnUserId: gameData.currentTurnUserId,
+                    turnStartTime: gameData.turnStartTime || Date.now(),
+                    turnTimeLimit: gameData.turnTimeLimit || 15,
+                    players: gameData.players || roomResponse.data.participants || [],
+                    usedWords: gameData.usedWords || [],
+                    winner: null,
+                })
+
+                setTimeLeft(gameData.turnTimeLimit || 15)
+
+                // WebSocket 연결
+                console.log('[WordchainPlayPage] Connecting WebSocket...')
+                await connect()
+                console.log('[WordchainPlayPage] WebSocket connected')
+            } catch (err) {
+                console.error('Failed to init game:', err)
+            } finally {
+                setLoading(false)
+            }
+        }
+
+        initGame()
+
+        return () => {
+            console.log('[WordchainPlayPage] Disconnecting WebSocket...')
+            disconnect()
+        }
+    }, [roomId, currentUserId, connect, disconnect])
+
+    // 타이머
+    useEffect(() => {
+        if (gameState.status !== 'PLAYING') return
+
+        const interval = setInterval(() => {
+            setTimeLeft(prev => {
+                if (prev <= 1) {
+                    // 시간 초과
+                    if (isMyTurn && isConnected) {
+                        console.log('[WordchainPlayPage] Timer expired, sending timeout')
+                        wordchainService.timeout(roomId).catch(err => {
+                            console.error('Failed to send timeout:', err)
+                        })
+                    }
+                    return 0
+                }
+                return prev - 1
+            })
+        }, 1000)
+
+        return () => clearInterval(interval)
+    }, [gameState.status, isMyTurn, isConnected, roomId])
+
+    // 단어 제출
+    const handleSubmitWord = async (word) => {
+        if (!isMyTurn || submitting) return
+
+        try {
+            setSubmitting(true)
+            await wordchainService.submit(roomId, word)
+            // 서버에서 WebSocket으로 결과 브로드캐스트
+        } catch (err) {
+            console.error('Failed to submit word:', err)
+            alert(err.response?.data?.message || err.message || '단어 제출에 실패했습니다')
+        } finally {
+            setSubmitting(false)
+        }
+    }
+
+    // 게임 종료
+    const handleStopGame = async () => {
+        try {
+            disconnect()
+            await wordchainService.stop(roomId)
+            sessionStorage.removeItem(`roomToken_${roomId}`)
+            navigate('/games/wordchain')
+        } catch (err) {
+            console.error('Failed to stop game:', err)
+        }
+    }
+
+    // 재시작
+    const handleRestart = async () => {
+        try {
+            disconnect()
+            await gameService.restartGame(roomId)
+            setShowEndModal(false)
+            navigate(`/games/wordchain/${roomId}/waiting`)
+        } catch (err) {
+            console.error('Failed to restart:', err)
+            setShowEndModal(false)
+            navigate(`/games/wordchain/${roomId}/waiting`)
+        }
+    }
+
+    // 나가기
+    const handleLeave = async () => {
+        try {
+            disconnect()
+            await gameService.leaveRoom(roomId)
+        } catch (err) {
+            console.error('Failed to leave room:', err)
+        }
+        sessionStorage.removeItem(`roomToken_${roomId}`)
+        navigate('/games/wordchain')
+    }
+
+    if (loading) {
+        return (
+            <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: '100vh' }}>
+                <CircularProgress sx={{ color: GAME_COLORS.primary }} />
+            </Box>
+        )
+    }
+
+    return (
+        <Box sx={{ minHeight: '100vh', bgcolor: isDark ? '#27272a' : '#F1F5F9', pb: 4 }}>
+            {/* 헤더 */}
+            <Box
+                sx={{
+                    bgcolor: GAME_COLORS.primary,
+                    color: 'white',
+                    px: 3,
+                    py: 2,
+                }}
+            >
+                <Container maxWidth="lg">
+                    <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+                        <Box sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
+                            <Typography variant="h6" fontWeight={700}>
+                                {room?.name || '끝말잇기'}
+                            </Typography>
+                            <Chip
+                                label={isConnected ? '연결됨' : '연결 중...'}
+                                size="small"
+                                sx={{
+                                    bgcolor: isConnected ? 'rgba(34,197,94,0.3)' : 'rgba(251,191,36,0.3)',
+                                    color: 'white',
+                                    fontWeight: 600,
+                                    height: 22,
+                                }}
+                            />
+                        </Box>
+
+                        <IconButton
+                            onClick={handleStopGame}
+                            size="small"
+                            sx={{ color: 'white', '&:hover': { bgcolor: 'rgba(255,255,255,0.1)' } }}
+                        >
+                            <StopIcon />
+                        </IconButton>
+                    </Box>
+                </Container>
+            </Box>
+
+            {/* WebSocket 에러 */}
+            {wsError && (
+                <Container maxWidth="lg" sx={{ mt: 2 }}>
+                    <Alert severity="error" sx={{ borderRadius: '12px' }}>
+                        {wsError}
+                    </Alert>
+                </Container>
+            )}
+
+            {/* 메인 컨텐츠 */}
+            <Container maxWidth="lg" sx={{ mt: 3 }}>
+                <Grid container spacing={3}>
+                    {/* 좌측: 게임 영역 */}
+                    <Grid item xs={12} md={8}>
+                        {/* 타이머 & 현재 턴 */}
+                        <Box
+                            sx={{
+                                display: 'flex',
+                                alignItems: 'center',
+                                justifyContent: 'space-between',
+                                mb: 3,
+                                p: 3,
+                                bgcolor: isDark ? '#27272a' : 'white',
+                                borderRadius: '16px',
+                            }}
+                        >
+                            <Box>
+                                <Typography variant="caption" color="text.secondary" gutterBottom>
+                                    현재 턴
+                                </Typography>
+                                <Typography variant="h6" fontWeight={700}>
+                                    {gameState.players.find(p => p.userId === gameState.currentTurnUserId)?.nickname ||
+                                        gameState.currentTurnUserId ||
+                                        '대기 중'}
+                                </Typography>
+                                {isMyTurn && (
+                                    <Chip
+                                        label="내 차례!"
+                                        size="small"
+                                        sx={{
+                                            mt: 0.5,
+                                            bgcolor: GAME_COLORS.primaryBg,
+                                            color: GAME_COLORS.primary,
+                                            fontWeight: 600,
+                                        }}
+                                    />
+                                )}
+                            </Box>
+                            <WordchainTimer timeLeft={timeLeft} timeLimit={gameState.turnTimeLimit} />
+                        </Box>
+
+                        {/* 현재 단어 & 다음 글자 */}
+                        <Box sx={{ mb: 3 }}>
+                            <WordDisplay
+                                currentWord={gameState.currentWord}
+                                nextLetter={gameState.nextLetter}
+                                isMyTurn={isMyTurn}
+                            />
+                        </Box>
+
+                        {/* 단어 입력 */}
+                        <Box
+                            sx={{
+                                p: 3,
+                                bgcolor: isDark ? '#27272a' : 'white',
+                                borderRadius: '16px',
+                            }}
+                        >
+                            <WordInput
+                                onSubmit={handleSubmitWord}
+                                disabled={submitting || timeLeft === 0}
+                                nextLetter={gameState.nextLetter}
+                                isMyTurn={isMyTurn}
+                            />
+                        </Box>
+                    </Grid>
+
+                    {/* 우측: 플레이어 & 사용된 단어 */}
+                    <Grid item xs={12} md={4}>
+                        {/* 플레이어 목록 */}
+                        <Box
+                            sx={{
+                                p: 2.5,
+                                bgcolor: isDark ? '#27272a' : 'white',
+                                borderRadius: '16px',
+                                mb: 3,
+                            }}
+                        >
+                            <PlayerList
+                                players={gameState.players}
+                                currentTurnUserId={gameState.currentTurnUserId}
+                                currentUserId={currentUserId}
+                            />
+                        </Box>
+
+                        {/* 사용된 단어 */}
+                        <Box
+                            sx={{
+                                p: 2.5,
+                                bgcolor: isDark ? '#27272a' : 'white',
+                                borderRadius: '16px',
+                            }}
+                        >
+                            <UsedWordsList words={gameState.usedWords} />
+                        </Box>
+                    </Grid>
+                </Grid>
+            </Container>
+
+            {/* 게임 종료 모달 */}
+            <GameEndModal
+                open={showEndModal}
+                winner={gameState.winner}
+                finalPlayers={gameState.players}
+                onRestart={handleRestart}
+                onExit={handleLeave}
+                currentUserId={currentUserId}
+            />
+        </Box>
+    )
+}
+
+export default WordchainPlayPage

--- a/src/domains/games/pages/WordchainWaitingPage.jsx
+++ b/src/domains/games/pages/WordchainWaitingPage.jsx
@@ -1,0 +1,393 @@
+import { useCallback, useEffect, useState } from 'react'
+import { useNavigate, useParams } from 'react-router-dom'
+import {
+    Alert,
+    Box,
+    Button,
+    Card,
+    Chip,
+    CircularProgress,
+    Container,
+    IconButton,
+    Typography,
+} from '@mui/material'
+import {
+    ArrowBack as ArrowBackIcon,
+    PlayArrow as PlayIcon,
+    Settings as SettingsIcon,
+} from '@mui/icons-material'
+import ParticipantList from '../components/ParticipantList'
+import WaitingChat from '../components/WaitingChat'
+import { gameService } from '../services/gameService'
+import { GAME_COLORS } from '../theme/gameTheme'
+import { useAuth } from '../../../contexts/AuthContext'
+import { useThemeMode } from '../../../contexts/ThemeContext'
+import { useChatWebSocket } from '../../freetalk/hooks/useChatWebSocket'
+
+const WordchainWaitingPage = () => {
+    const { roomId } = useParams()
+    const navigate = useNavigate()
+    const { user } = useAuth()
+    const { mode } = useThemeMode()
+    const isDark = mode === 'dark'
+    const currentUserId = user?.userId || user?.username || user?.sub
+
+    // WebSocket 연결
+    const {
+        isConnected,
+        messages: wsMessages,
+        gameState: wsGameState,
+        error: wsError,
+        connect,
+        disconnect,
+        sendMessage: wsSendMessage,
+    } = useChatWebSocket(roomId, currentUserId)
+
+    const [room, setRoom] = useState(null)
+    const [loading, setLoading] = useState(true)
+    const [error, setError] = useState(null)
+    const [starting, setStarting] = useState(false)
+
+    // 채팅 메시지 (WebSocket 연동)
+    const [messages, setMessages] = useState([
+        {
+            id: 'system-1',
+            content: '게임 대기실에 입장했습니다.',
+            isSystem: true,
+            createdAt: new Date().toISOString(),
+        },
+    ])
+
+    // WebSocket 메시지 동기화
+    useEffect(() => {
+        if (wsMessages && wsMessages.length > 0) {
+            setMessages(prev => {
+                const systemMessages = prev.filter(m => m.isSystem && m.id === 'system-1')
+                const existingIds = new Set(systemMessages.map(m => m.id))
+                const uniqueWsMessages = wsMessages.filter(m => !existingIds.has(m.id))
+                const allMessages = [...systemMessages, ...uniqueWsMessages]
+                const seen = new Set()
+                return allMessages.filter(m => {
+                    if (seen.has(m.id)) return false
+                    seen.add(m.id)
+                    return true
+                })
+            })
+        }
+    }, [wsMessages])
+
+    // 게임 시작 감지 (WebSocket GAME_START 이벤트)
+    useEffect(() => {
+        if (wsGameState?.status === 'PLAYING') {
+            console.log('[WordchainWaitingPage] Game started via WebSocket, navigating to play page')
+            navigate(`/games/wordchain/${roomId}/play`)
+        }
+    }, [wsGameState?.status, roomId, navigate])
+
+    // 방 정보 조회
+    const fetchRoom = useCallback(async (showLoading = false) => {
+        try {
+            if (showLoading) {
+                setLoading(true)
+            }
+            const response = await gameService.getRoom(roomId)
+            setRoom(response.data)
+
+            // 게임이 시작되면 플레이 페이지로 이동
+            if (response.data.status === 'PLAYING') {
+                navigate(`/games/wordchain/${roomId}/play`)
+            }
+        } catch (err) {
+            console.error('Failed to fetch room:', err)
+            setError('방 정보를 불러오는데 실패했습니다')
+        } finally {
+            if (showLoading) {
+                setLoading(false)
+            }
+        }
+    }, [roomId, navigate])
+
+    // 초기 로딩 및 WebSocket 연결
+    useEffect(() => {
+        const init = async () => {
+            await fetchRoom(true)
+            console.log('[WordchainWaitingPage] Connecting WebSocket...')
+            try {
+                await connect()
+                console.log('[WordchainWaitingPage] WebSocket connected')
+            } catch (err) {
+                console.error('[WordchainWaitingPage] WebSocket connection failed:', err)
+            }
+        }
+        init()
+
+        return () => {
+            console.log('[WordchainWaitingPage] Disconnecting WebSocket...')
+            disconnect()
+        }
+    }, []) // eslint-disable-line react-hooks/exhaustive-deps
+
+    // 주기적 새로고침
+    useEffect(() => {
+        const interval = setInterval(() => fetchRoom(false), 3000)
+        return () => clearInterval(interval)
+    }, [fetchRoom])
+
+    // 게임 시작
+    const handleStartGame = async () => {
+        try {
+            setStarting(true)
+            await gameService.startGame(roomId)
+            navigate(`/games/wordchain/${roomId}/play`)
+        } catch (err) {
+            console.error('Failed to start game:', err)
+            const errorMessage = err.response?.data?.message || err.message || '게임 시작에 실패했습니다'
+            setError(errorMessage)
+        } finally {
+            setStarting(false)
+        }
+    }
+
+    // 방 나가기
+    const handleLeaveRoom = async () => {
+        try {
+            disconnect()
+            await gameService.leaveRoom(roomId)
+            sessionStorage.removeItem(`roomToken_${roomId}`)
+            navigate('/games/wordchain')
+        } catch (err) {
+            console.error('Failed to leave room:', err)
+        }
+    }
+
+    // 채팅 메시지 전송
+    const handleSendMessage = (content) => {
+        if (isConnected) {
+            console.log('[WordchainWaitingPage] Sending message via WebSocket:', content)
+            wsSendMessage(content, 'TEXT')
+        } else {
+            const newMessage = {
+                id: `msg-${Date.now()}`,
+                userId: currentUserId,
+                nickname: user?.nickname || user?.username || '플레이어',
+                content,
+                createdAt: new Date().toISOString(),
+            }
+            setMessages(prev => [...prev, newMessage])
+        }
+    }
+
+    const isHost = room?.hostId === currentUserId
+    const canStart = isHost && room?.currentParticipants >= 2
+
+    if (loading) {
+        return (
+            <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: '100vh' }}>
+                <CircularProgress sx={{ color: GAME_COLORS.primary }} />
+            </Box>
+        )
+    }
+
+    if (!room) {
+        return (
+            <Container maxWidth="sm" sx={{ py: 8, textAlign: 'center' }}>
+                <Typography variant="h6" color="error">
+                    방을 찾을 수 없습니다
+                </Typography>
+                <Button onClick={() => navigate('/games/wordchain')} sx={{ mt: 2 }}>
+                    로비로 돌아가기
+                </Button>
+            </Container>
+        )
+    }
+
+    return (
+        <Box sx={{ minHeight: '100vh', bgcolor: isDark ? '#27272a' : '#F8FAFC' }}>
+            {/* 헤더 */}
+            <Box
+                sx={{
+                    bgcolor: GAME_COLORS.primary,
+                    color: 'white',
+                    py: 2,
+                    px: 3,
+                }}
+            >
+                <Container maxWidth="lg">
+                    <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+                        <Box sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
+                            <IconButton onClick={handleLeaveRoom} sx={{ color: 'white' }}>
+                                <ArrowBackIcon />
+                            </IconButton>
+                            <Box>
+                                <Typography variant="h6" fontWeight={700}>
+                                    {room.name}
+                                </Typography>
+                                <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                                    <Chip
+                                        label={`${room.currentParticipants}/${room.maxParticipants}명`}
+                                        size="small"
+                                        sx={{
+                                            bgcolor: 'rgba(255,255,255,0.2)',
+                                            color: 'white',
+                                            fontWeight: 600,
+                                            height: 22,
+                                        }}
+                                    />
+                                    <Chip
+                                        label="대기중"
+                                        size="small"
+                                        sx={{
+                                            bgcolor: GAME_COLORS.status.waitingBg,
+                                            color: GAME_COLORS.status.waiting,
+                                            fontWeight: 600,
+                                            height: 22,
+                                        }}
+                                    />
+                                    <Chip
+                                        label={isConnected ? '연결됨' : '연결 중...'}
+                                        size="small"
+                                        sx={{
+                                            bgcolor: isConnected ? 'rgba(34,197,94,0.3)' : 'rgba(251,191,36,0.3)',
+                                            color: 'white',
+                                            fontWeight: 600,
+                                            height: 22,
+                                            fontSize: '0.7rem',
+                                        }}
+                                    />
+                                </Box>
+                            </Box>
+                        </Box>
+
+                        {isHost && (
+                            <IconButton sx={{ color: 'white' }}>
+                                <SettingsIcon />
+                            </IconButton>
+                        )}
+                    </Box>
+                </Container>
+            </Box>
+
+            {/* 에러 */}
+            {(error || wsError) && (
+                <Container maxWidth="lg" sx={{ mt: 2 }}>
+                    <Alert severity="error" onClose={() => setError(null)} sx={{ borderRadius: '12px' }}>
+                        {error || wsError}
+                    </Alert>
+                </Container>
+            )}
+
+            {/* 메인 컨텐츠 */}
+            <Container maxWidth="lg" sx={{ py: 3 }}>
+                <Box
+                    sx={{
+                        display: 'grid',
+                        gridTemplateColumns: { xs: '1fr', md: '300px 1fr' },
+                        gap: 3,
+                        height: 'calc(100vh - 200px)',
+                    }}
+                >
+                    {/* 좌측: 참가자 목록 */}
+                    <Card
+                        sx={{
+                            p: 2,
+                            borderRadius: '16px',
+                            height: 'fit-content',
+                        }}
+                    >
+                        <ParticipantList
+                            participants={room.participants || []}
+                            maxParticipants={room.maxParticipants}
+                            currentUserId={currentUserId}
+                        />
+                    </Card>
+
+                    {/* 우측: 대기 채팅 */}
+                    <Card
+                        sx={{
+                            borderRadius: '16px',
+                            display: 'flex',
+                            flexDirection: 'column',
+                            overflow: 'hidden',
+                        }}
+                    >
+                        <Box sx={{ p: 2, borderBottom: '1px solid', borderColor: 'divider' }}>
+                            <Typography variant="subtitle1" fontWeight={700}>
+                                대기 채팅
+                            </Typography>
+                        </Box>
+                        <Box sx={{ flex: 1, minHeight: 0 }}>
+                            <WaitingChat
+                                messages={messages}
+                                onSendMessage={handleSendMessage}
+                                currentUserId={currentUserId}
+                            />
+                        </Box>
+                    </Card>
+                </Box>
+
+                {/* 하단: 게임 설정 + 시작 버튼 */}
+                <Card
+                    sx={{
+                        mt: 3,
+                        p: 2.5,
+                        borderRadius: '16px',
+                        display: 'flex',
+                        alignItems: 'center',
+                        justifyContent: 'space-between',
+                        flexWrap: 'wrap',
+                        gap: 2,
+                    }}
+                >
+                    <Box sx={{ display: 'flex', alignItems: 'center', gap: 3 }}>
+                        <Box>
+                            <Typography variant="caption" color="text.secondary">
+                                턴 시간
+                            </Typography>
+                            <Typography variant="body1" fontWeight={700}>
+                                {room.gameSettings?.turnTimeLimit || 15}초
+                            </Typography>
+                        </Box>
+                        <Box>
+                            <Typography variant="caption" color="text.secondary">
+                                난이도
+                            </Typography>
+                            <Typography variant="body1" fontWeight={700}>
+                                {room.level || 'INTERMEDIATE'}
+                            </Typography>
+                        </Box>
+                    </Box>
+
+                    {isHost ? (
+                        <Button
+                            variant="contained"
+                            size="large"
+                            startIcon={<PlayIcon />}
+                            onClick={handleStartGame}
+                            disabled={!canStart || starting}
+                            sx={{
+                                bgcolor: canStart ? GAME_COLORS.status.waiting : '#9CA3AF',
+                                '&:hover': { bgcolor: canStart ? '#059669' : '#9CA3AF' },
+                                borderRadius: '12px',
+                                textTransform: 'none',
+                                fontWeight: 700,
+                                px: 4,
+                                py: 1.5,
+                            }}
+                        >
+                            {starting ? '시작 중...' : canStart ? '게임 시작' : '2명 이상 필요'}
+                        </Button>
+                    ) : (
+                        <Box sx={{ textAlign: 'center' }}>
+                            <Typography variant="body2" color="text.secondary">
+                                방장이 게임을 시작할 때까지 기다려주세요
+                            </Typography>
+                            <CircularProgress size={24} sx={{ mt: 1, color: GAME_COLORS.primary }} />
+                        </Box>
+                    )}
+                </Card>
+            </Container>
+        </Box>
+    )
+}
+
+export default WordchainWaitingPage

--- a/src/domains/games/services/wordchainService.js
+++ b/src/domains/games/services/wordchainService.js
@@ -1,0 +1,58 @@
+/**
+ * Word Chain Service - 백엔드 API 연동
+ * 영어 끝말잇기 게임 관련 REST API 호출
+ */
+import chatApi from '../../../api/chatApi'
+
+/**
+ * 끝말잇기 게임 진행 관련 API
+ */
+export const wordchainService = {
+    /**
+     * 게임 시작
+     * @param {string} roomId
+     */
+    start: async (roomId) => {
+        const response = await chatApi.post(`/chat/rooms/${roomId}/wordchain/start`, {})
+        return response.data
+    },
+
+    /**
+     * 단어 제출
+     * @param {string} roomId
+     * @param {string} word
+     */
+    submit: async (roomId, word) => {
+        const response = await chatApi.post(`/chat/rooms/${roomId}/wordchain/submit`, { word })
+        return response.data
+    },
+
+    /**
+     * 타임아웃 처리
+     * @param {string} roomId
+     */
+    timeout: async (roomId) => {
+        const response = await chatApi.post(`/chat/rooms/${roomId}/wordchain/timeout`, {})
+        return response.data
+    },
+
+    /**
+     * 게임 중단
+     * @param {string} roomId
+     */
+    stop: async (roomId) => {
+        const response = await chatApi.post(`/chat/rooms/${roomId}/wordchain/stop`, {})
+        return response.data
+    },
+
+    /**
+     * 게임 상태 조회
+     * @param {string} roomId
+     */
+    getStatus: async (roomId) => {
+        const response = await chatApi.get(`/chat/rooms/${roomId}/wordchain/status`)
+        return response.data
+    },
+}
+
+export default wordchainService

--- a/src/layouts/MainLayout/Sidebar/index.jsx
+++ b/src/layouts/MainLayout/Sidebar/index.jsx
@@ -169,6 +169,13 @@ const Sidebar = ({open, collapsed, onToggleCollapse, onClose}) => {
                             path: '/games/catchmind',
                             description: t('games.catchmindDesc'),
                         },
+                        {
+                            id: 'wordchain',
+                            label: '끝말잇기',
+                            icon: GameIcon,
+                            path: '/games/wordchain',
+                            description: '영어 끝말잇기',
+                        },
                     ],
                 },
             ],


### PR DESCRIPTION
## Summary
- 영어 끝말잇기 게임 구현 (캐치마인드와 동일한 구조)
- 이전 단어의 마지막 글자로 시작하는 단어를 제출하는 게임

## 게임 규칙
- 각 플레이어가 차례대로 단어 제출
- 이전 단어의 마지막 글자로 시작해야 함
- 시간 초과 시 탈락
- 마지막 1명 남으면 승리

### 시간 제한 (라운드별 감소)
| 라운드 | 시간 |
|--------|------|
| 1-2 | 15초 |
| 3-4 | 13초 |
| 5-6 | 11초 |
| 7-8 | 9초 |
| 9+ | 8초 |

## 구현 파일

### 서비스
- `wordchainService.js` - API 호출 (start, submit, timeout, stop, status)

### 페이지
- `WordchainLobbyPage.jsx` - 게임 로비
- `WordchainWaitingPage.jsx` - 대기실
- `WordchainPlayPage.jsx` - 게임 플레이

### 컴포넌트
- `WordDisplay.jsx` - 현재 단어 & 다음 글자
- `WordchainTimer.jsx` - 원형 타이머
- `PlayerList.jsx` - 플레이어 목록 (활성/탈락)
- `UsedWordsList.jsx` - 사용된 단어 목록
- `WordInput.jsx` - 단어 입력
- `GameEndModal.jsx` - 종료 모달 (순위, 단어 학습)

### 기타
- WebSocket 핸들러 추가 (wordchain_*)
- 라우트 추가 (/games/wordchain/*)
- 사이드바 네비게이션 추가

## Test plan
- [ ] 로비에서 방 생성/참가
- [ ] 대기실에서 게임 시작
- [ ] 단어 입력 및 검증
- [ ] 타이머 동작 확인
- [ ] 탈락 처리 확인
- [ ] 게임 종료 및 순위 표시